### PR TITLE
修复知网默认不能获取学位论文（caj）的问题 

### DIFF
--- a/translators/CNKI.js
+++ b/translators/CNKI.js
@@ -354,7 +354,7 @@ function getCAJ(doc, itemType) {
 // add pdf or caj to attachments, default is pdf
 function getAttachments(pdfurl, cajurl, keepPDF) {
 	var attachments = [];
-	if (keepPDF && cajurl) {
+	if (keepPDF && pdfurl) {
 		var url = pdfurl ? pdfurl : cajurl.includes("&dflag=nhdown") ? cajurl.replace('&dflag=nhdown', '&dflag=pdfdown') : cajurl + '&dflag=pdfdown';
 		url = url.replace(/kns\.cnki\.net\/KNS8/, "oversea.cnki.net/kns");
 		attachments.push({


### PR DESCRIPTION
解决 #54 

当前pdf/caj策略：
- CNKIPDF=true：优先获取pdf，若无则获取caj
- CNKIPDF=false：获取caj