### PR TITLE
fix: 读秀图书名称空格增多问题

### DIFF
--- a/translators/Duxiu.js
+++ b/translators/Duxiu.js
@@ -9,7 +9,7 @@
 	"inRepository": true,
 	"translatorType": 4,
 	"browserSupport": "gcsibv",
-	"lastUpdated": "2022-06-29 02:01:12"
+	"lastUpdated": "2022-11-29 09:12:10"
 }
 
 /*
@@ -97,7 +97,9 @@ function scrapeAndParse(doc, url) {
 		if (pattern.test(page)) {
 			Z.debug("test");
 			var title = pattern.exec(page)[1];
-			newItem.title = Zotero.Utilities.trim(title);
+			title = Zotero.Utilities.trim(title);
+			title = title.replace(/ +/g, " "); // https://developer.mozilla.org/docs/Web/CSS/white-space
+			newItem.title = title;
 		}
 		//newItem.title="test";
 		


### PR DESCRIPTION
例 https://book.duxiu.com/bookDetail.jsp?dxNumber=000000761038&d=B60E2E205143A4C5826DD9F9D0F1EFAF
网页源码为：
> <dt>马克思恩格斯通信集&nbsp; 第2卷&nbsp; 1854-1860</dt>
等。

实际书名、实际显示和用户复制，是没有双空格的，浏览器标准会自动合并连续空格。