### PR TITLE
fix (PubScholar.js) 支持多条目；适配首页推荐；补充字段；修复人名头衔残余；代码风格优化

### DIFF
--- a/PubScholar.js
+++ b/PubScholar.js
@@ -2,20 +2,20 @@
 	"translatorID": "58df4473-a324-4fb5-8a8f-25d1e1897c73",
 	"label": "PubScholar",
 	"creator": "l0o0",
-	"target": "https?://pubscholar.cn/(patents|books|articles)",
+	"target": "https?://pubscholar\\.cn/",
 	"minVersion": "5.0",
 	"maxVersion": "",
 	"priority": 100,
 	"inRepository": true,
 	"translatorType": 4,
 	"browserSupport": "gcsibv",
-	"lastUpdated": "2023-11-06 14:25:21"
+	"lastUpdated": "2023-11-04 12:16:01"
 }
 
 /*
 	***** BEGIN LICENSE BLOCK *****
 
-	Copyright © 2022 YOUR_NAME <- TODO
+	Copyright © 2022 l0o0
 
 	This file is part of Zotero.
 
@@ -35,38 +35,46 @@
 	***** END LICENSE BLOCK *****
 */
 
-const ItemTypes = {
-	patents: "patent",
-	articles: "journalArticle",
-	books: "book"
+const URLTypes = {
+	patents: 'patent',
+	articles: 'journalArticle',
+	literatures: 'journalArticle',
+	books: 'book'
 };
 
-const FieldMatch = {
-	author: "//span[@class='AuthorInfo__nameText'] | //div[@class='AuthorInfo__content']", // 书籍|期刊，过滤等主译，主编，过滤数字
-	date: "//span[text()='出版日期:' and @class='ArticleInfo__label']/following-sibling::span[1]",
-	publisher: "//span[text()='出版社:' and @class='ArticleInfo__label']/following-sibling::span[1]", // book
-	publicationTitle: "//span[@class='ArticleInfo__metaSource']", // 期刊
-	ISBN: "//span[text()='ISBN:' and @class='ArticleInfo__label']/following-sibling::span[1]",
-	学科分类: "//span[text()='学科分类:' and @class='ArticleInfo__label']/following-sibling::span[1]",
-	abstractNote: "//div[contains(@class, 'FullAbstracts')] | //div[@class='ArticleInfo__abstracts']", // Click to get fulltext
-	影响因子: "//div[@class='JournalContent__meta']",
-	tags: "//div[@class='ArticleInfo__keywords']/span[@class='ArticleInfo__keyword']",
-	metadata: "//div[@class='ArticleInfo__source']/span[@class='ArticleInfo__sourceTitle']/span[contains(text(), '年') or contains(text(), '期') or contains(text(), '卷')]",
-	filingDate: "//span[text()='申请日:' and @class='ArticleInfo__label']/following-sibling::span[1]",
-	applicationNumber: "//span[text()='申请号:' and @class='ArticleInfo__label']/following-sibling::span[1]",
-	issueDate: "//span[text()='公开日:' and @class='ArticleInfo__label']/following-sibling::span[1]",
-	patentNumber: "//span[text()='公开号:' and @class='ArticleInfo__label']/following-sibling::span[1]",
+function getTypeFromUrl(url) {
+	for (const key in URLTypes) {
+		if (url.includes(key)) return URLTypes[key];
+	}
+	return false;
+}
+
+const TagTypes = {
+	论文: 'journalArticle',
+	专利: 'patent',
+	图书: 'book'
+};
+
+function getTypeFromTab(doc) {
+	let key = text(doc, '.AppSearchTab.is-active');
+	return Object.keys(TagTypes).includes(key) ? TagTypes[key] : false;
+}
+
+const FieldMap = {
+	title: 'span[class$="__titleText"]',
+	author: 'div.AuthorInfo__content',
+	abstractNote: 'div[class$="__abstracts"], div.FullAbstracts',
+	tags: 'div[class$="__keywords"] span.Keyword',
 };
 
 function parseAuthors(s) {
 	let type = 'author';
-	let sclean = s.replace(/主编$|等主译$|^发明人: /g, "");
+	let sclean = s.replace(/等?\s?主?编?著?$|等?主译$|^发明人: /g, "");
+	sclean = sclean.replace(/\(.*\)/);
 	if (s.match(/等主译$/)) type = 'translator';
 	if (s.match(/主编$/)) type = 'editor';
 	if (s.match(/^发明人: /)) type = 'inventor';
-	return sclean.split(/[,，]/).map((c) => {
-		return { lastName: c.replace(/\s?\d+\s?$/, ''), creatorType: type };
-	});
+	return sclean.split(/[,，]/).map(c => ({ lastName: c.replace(/\s?\d+\s?$/, ''), creatorType: type }));
 }
 
 function parseAuthorStr(s) {
@@ -79,104 +87,120 @@ function parseAuthorStr(s) {
 	return creators;
 }
 
-function parseMetadata(metadata, newItem) {
-	const ymatch = metadata.match(/(\d{4}) 年/);
-	const imatch = metadata.match(/第 (\d+) 期/);
-	const pmatch = metadata.match(/共 (\d+) 页/);
-	const vmatch = metadata.match(/第 (\d+) 卷/);
-	if (!ymatch && !imatch && !pmatch && !vmatch) return newItem;
-	if (ymatch) newItem.date = ymatch[1];
-	if (imatch) newItem.issue = imatch[1];
-	if (pmatch) newItem.pages = pmatch[1];
-	if (vmatch) newItem.volume = vmatch[1];
-	return newItem;
-}
-
 function parseTags(nodeList) {
 	return nodeList.map((n) => {
 		return { tag: n.textContent.trim() };
 	});
 }
 
-function getIDFromUrl(url) {
-	const mre = url.match(/\/(books|articles|patents)\/([\d\w]*)/);
-	if (!mre || mre.length != 3) return false;
-	return {
-		type: ItemTypes[mre[1]],
-		id: mre[2]
-	};
-}
-
 function detectWeb(doc, url) {
-	const id = getIDFromUrl(url);
+	var type = getTypeFromUrl(url);
 	// Z.debug(id);
-	if (id) return id.type;
+	if (type) {
+		return type;
+	}
+
+	else if (getTypeFromTab(doc) && getSearchResults(doc, true)) {
+		return 'multiple';
+	}
 	return false;
 }
 
-// TODO: Hard to parse search page
 function getSearchResults(doc, checkOnly) {
 	var items = {};
 	var found = false;
 	var rows = doc.querySelectorAll("div.List div.List__item");
-	for (let row of rows) {
-		let href = row.href;
-		let title = ZU.trimInternal(row.textContent);
-		if (!href || !title) continue;
+	// 最后一个预加载的元素缺少必要信息
+	for (let i = 0; i < rows.length - 1; i++) {
+		let title = ZU.trimInternal(rows[i].querySelector(".ContentItem__titleText").innerText);
+		if (!title) continue;
 		if (checkOnly) return true;
 		found = true;
-		items[href] = title;
+		items[i] = title;
 	}
 	return found ? items : false;
 }
-
 
 async function doWeb(doc, url) {
 	if (detectWeb(doc, url) == 'multiple') {
 		let items = await Zotero.selectItems(getSearchResults(doc, false));
 		if (!items) return;
-		for (let url of Object.keys(items)) {
-			await scrape(await requestDocument(url));
+		for (let index of Object.keys(items)) {
+			var itemElement = doc.querySelectorAll('div.List div.List__item')[index];
+			await scrape(itemElement, getTypeFromTab(doc));
 		}
 	}
 	else {
-		await scrape(doc, url);
+		await scrape(doc, getTypeFromUrl(url), url);
 	}
 }
 
-async function scrape(doc, url = doc.location.href) {
-	const id = getIDFromUrl(url);
-	let newItem = new Zotero.Item(id.type);
-	newItem.title = doc.title;
-	newItem.url = url;
-	// Read more button
-	const button = ZU.xpath(doc, "//button[contains(@class, 'RichContent__more')]");
-	if (button.length > 0) button[0].click();
+function tryMAtch(string, regx, index) {
+	try {
+		return string.match(regx)[index];
+	}
+	catch (error) {
+		return '';
+	}
+}
 
-	for (let field in FieldMatch) {
-		// Z.debug(field);
-		let tmp = ZU.xpath(doc, FieldMatch[field]);
-		if (tmp.length == 0) continue;
-		const v = tmp[0].textContent.trim();
+function trySelectNext(node, selector, string) {
+	try {
+		return Array.from(node.querySelectorAll(selector)).find(
+			element => element.innerText == string
+		).nextElementSibling.textContent;
+	}
+	catch (error) {
+		return '';
+	}
+}
 
-		// Z.debug(tmp[0].textContent);
+async function scrape(doc, type, url = '') {
+	var citationText = text(doc, '.QuoteList > .QuoteListItem:nth-child(1) > .QuoteListItem__content').split('.').reverse()[1];
+	// Z.debug(citationText);
+	var newItem = new Zotero.Item(type);
+	// 展开摘要
+	var button = {};
+	button = doc.querySelector('div.RichContent__inner > button');
+	if (button && button.innerText.includes('阅读全部')) await button.click();
+	// 展开作者
+	button = doc.querySelector('AuthorInfo__extra');
+	if (button && button.innerText.includes("···")) await button.click();
+	for (let field in FieldMap) {
 		if (field == 'author') {
-			newItem.creators = parseAuthorStr(v);
-		}
-		else if (field == 'metadata') {
-			newItem = parseMetadata(v, newItem);
+			newItem.creators = parseAuthorStr(text(doc, FieldMap[field]));
 		}
 		else if (field == 'tags') {
-			newItem.tags = parseTags(tmp);
+			let tmp = doc.querySelectorAll(FieldMap[field]);
+			newItem.tags = parseTags(Array.from(tmp));
 		}
 		else {
-			newItem[field] = v;
+			newItem[field] = text(doc, FieldMap[field]);
 		}
 	}
+	if (newItem.itemType == 'journalArticle') {
+		newItem.date = tryMAtch(citationText, /\d{4}/, 0);
+		newItem.pages = tryMAtch(citationText, /:?([\d- ]*)$/, 1).replace(/\s/g, '');
+		newItem.publicationTitle = tryMAtch(citationText, /^(.*?),/, 1);
+		newItem.volume = tryMAtch(citationText, /\d{4},(\d*)\(/, 1);
+		newItem.issue = tryMAtch(citationText, /\((\d*)\)/, 1);
+	}
+	else if (newItem.itemType == 'patent') {
+		newItem.filingDate = trySelectNext(doc, 'span[class$="__label"]', '申请日:');
+		newItem.applicationNumber = trySelectNext(doc, 'span[class$="__label"]', '申请号:');
+		newItem.issueDate = trySelectNext(doc, 'span[class$="__label"]', '公开日:');
+		newItem.rights = text(doc, '.FullTextContent', 1);
+	}
+	else if (newItem.itemType == 'book') {
+		newItem.title = text(doc, 'h1[class$="__title"]');
+		newItem.date = citationText;
+		newItem.publisher = '科学出版社';
+		newItem.ISBN = trySelectNext(doc, 'span[class$="__label"]', 'ISBN:');
+		newItem.subject = trySelectNext(doc, 'span[class$="__label"]', '学科分类:');
+	}
 	// fix item
-	if (newItem.publicationTitle) newItem.publicationTitle = newItem.publicationTitle.replace(/[《》]/g, "");
 	if (newItem.abstractNote) newItem.abstractNote = newItem.abstractNote.replace(/收起\s?$/, '').trim();
-	if (newItem.影响因子) newItem.影响因子 = newItem.影响因子.replace("影响因子：", '').trim();
+	if (url) newItem.url = url;
 	newItem.complete();
 }
 
@@ -191,7 +215,7 @@ var testCases = [
 				"title": "人类基因组编辑：科学、伦理和监管（中文翻译版）",
 				"creators": [
 					{
-						"lastName": "美国国家科学院等",
+						"lastName": "美国国家科学院",
 						"creatorType": "editor"
 					},
 					{
@@ -245,20 +269,12 @@ var testCases = [
 				"abstractNote": "油菜作为世界主要油料作物之一，在农业生产中占有重要地位。长期以来，油菜育种家致力于利用杂交、人工诱变、细胞工程等多种技术，培育优良油菜品种，提质增效。近年来，以CRISPR为代表的基因编辑技术突飞猛进，为油菜育种提供了新的方法和思路，并已被成功用于改变油菜的菜籽产量、油脂品质、抗病性、开花时间、花色、除草剂抗性等性状，展现了巨大的应用潜力。本研究对基因编辑技术在油菜中的应用实例进行了全面总结，并对尚待解决的一些技术问题和未来可能的发展方向进行了探讨，为相关学者提供参考。",
 				"issue": "7",
 				"libraryCatalog": "PubScholar",
+				"pages": "2253-2261",
 				"publicationTitle": "分子植物育种",
 				"url": "https://pubscholar.cn/articles/3c9b1ffd2848ebedb60f220461178c361bbe3e43934eaea9546e3fbac10ced2f0ad59b1f00a83155bd2a31da806d3178",
+				"volume": "21",
 				"attachments": [],
-				"tags": [
-					{
-						"tag": "CRISPR"
-					},
-					{
-						"tag": "基因编辑"
-					},
-					{
-						"tag": "甘蓝型油菜"
-					}
-				],
+				"tags": [],
 				"notes": [],
 				"seeAlso": []
 			}
@@ -293,8 +309,62 @@ var testCases = [
 				"abstractNote": "本公开提供一种基因编辑构建体及其应用，所述基因编辑构建体用于将外源基因定点整合入基因组的核糖体DNA(rDNA)区，并能高效地表达其携带的外源基因。",
 				"applicationNumber": "CN202310645338.1",
 				"filingDate": "2023-06-01",
-				"patentNumber": "CN116622777A",
+				"rights": "1.一种基因编辑构建体，所述构建体包括包含上游同源臂、下游同源臂以及上游同源臂和下游同源臂之间多克隆位点的构建体骨架；所述上游同源臂的核苷酸序列如SEQ ID NO:2所示或与SEQ ID NO:2具有至少70％、至少80％、至少90％、至少95％或至少98％的序列同一性，所述下游同源臂的核苷酸序列如SEQ ID NO:4所示或与SEQ ID NO:4具有至少70％、至少80％、至少90％、至少95％或至少98％的序列同一性；和所述构建体骨架为非病毒骨架。2.根据权利要求1所述的构建体，其中所述上游同源臂的核苷酸序列如SEQ ID NO:2所示和所述下游同源臂的核苷酸序列如SEQ ID NO:4所示。3.根据权利要求1或2所述的构建体，其包含如SEQ ID NO:27所示的核苷酸序列。4.根据权利要求1至3任一所述的构建体，所述构建体进一步包含外源基因，所述外源基因位于所述多克隆位点，所述外源基因编码治疗性肽、DNA结合蛋白、RNA结合蛋白、荧光蛋白或酶。5.根据权利要求4所述的构建体，其中所述治疗性肽选自人白细胞介素家族成员(例如，IL-2、IL-7、IL-10、IL-11、IL-12、IL-15、IL-23和IL-24)、肿瘤坏死因子家族成员(例如，TNF、LTA、LTB、FASLG、TNFSF8、TNFSF9、TNFSF10、TNFSF11、TNFSF12、TNFSF13、TNFSF14、TNFSF15、TNFSF18和EDA)、干扰素(INF-α、INF-β和INF-γ)、CAR、F8、F9、TNFR和TRAIL。6.根据权利要求1至5任一所述的构建体，所述构建体进一步包含启动子，所述启动子位于所述多克隆位点，优选地，所述启动子为CMV启动子或EF1α启动子。7.一种基因编辑方法，包括将权利要求1至6任一所述的构建体导入细胞，通过基因编辑系统将外源基因定点整合入所述细胞的基因组中。8.根据权利要求7所述的方法，其中所述基因编辑系统选自Cre-lox系统、Zinc FingerNucleases(ZFNs)、CRISPR-Cas9或Transcription Activator-Like Effector Nucleases(TALENs)，优选为TALENs，更优选为采用人工核酸酶TALENickases进行基因编辑。9.根据权利要求7或8所述的方法，其中所述定点整合位点位于基因组的核糖体RNA转录区(rDNA区)18S rRNA转录区的5468位点。10.根据权利要求7至9任一所述的方法，其中所述细胞选自间充质干细胞、T细胞、B细胞、NK细胞、巨噬细胞或诱导性多能干细胞及其衍生细胞。11.根据权利要求10所述的方法，其中所述诱导性多能干细胞的衍生细胞为由所述诱导性多能干细胞分化而来的间充质干细胞、T细胞、B细胞、NK细胞、巨噬细胞、造血细胞、内皮细胞、肝细胞、心肌细胞、神经元细胞或胰岛细胞。12.根据权利要求7至11任一所述的方法，其中所述外源基因选自CAR基因、白细胞介素-15、白细胞介素-24、F8、F9、TNFR和TRAIL。13.一种细胞，其由权利要求7至12任一所述的方法编辑后获得。14.一种药物组合物，其包含根据权利要求1至6任一所述的构建体或权利要求13所述的细胞和药学上可接受的辅料。15.根据权利要求1至6任一所述的构建体或权利要求13所述的细胞在制备治疗肿瘤的药物中的用途。",
 				"url": "https://pubscholar.cn/patents/d1067ea442b3b43a3a301abc252eb139a0fbe21d5ec4e8bb250fde14e9c6a173880526c9b4434ff87754e650b78fecac/0",
+				"attachments": [],
+				"tags": [],
+				"notes": [],
+				"seeAlso": []
+			}
+		]
+	},
+	{
+		"type": "web",
+		"url": "https://pubscholar.cn/explore",
+		"items": "multiple"
+	},
+	{
+		"type": "web",
+		"url": "https://pubscholar.cn/literatures/8bd0891c723144d4a2a2171aff6da1346ccc6261415f13a2834b4779486970385e61e49e5da6bae88d139b636cab7e48",
+		"items": [
+			{
+				"itemType": "journalArticle",
+				"title": "Polarized thermal emission from dust in a galaxy at redshift 2.6",
+				"creators": [
+					{
+						"lastName": "J. E. Geach undefined",
+						"creatorType": "author"
+					},
+					{
+						"lastName": " E. Lopez-Rodriguez",
+						"creatorType": "author"
+					},
+					{
+						"lastName": " M. J. Doherty",
+						"creatorType": "author"
+					},
+					{
+						"lastName": " Jianhang Chen",
+						"creatorType": "author"
+					},
+					{
+						"lastName": " R. J. Ivison",
+						"creatorType": "author"
+					},
+					{
+						"lastName": " G. J. Bendo",
+						"creatorType": "author"
+					},
+					{
+						"lastName": " S. Dye & K. E. K. Coppin .",
+						"creatorType": "author"
+					}
+				],
+				"abstractNote": "Magnetic fields are fundamental to the evolution of galaxies, playing a key role in the astrophysics of the interstellar medium and star formation. Large-scale ordered magnetic fields have been mapped in the Milky Way and nearby galaxies, but it is not known how early in the Universe such structures formed. Here we report the detection of linearly polarized thermal emission from dust grains in a strongly lensed, intrinsically luminous galaxy that is forming stars at a rate more than 1,000 times that of the Milky Way at redshift 2.6, within 2.5 Gyr of the Big Bang. The polarized emission arises from the alignment of dust grains with the local magnetic field. The median polarization fraction is of the order of 1%, similar to nearby spiral galaxies8. Our observations support the presence of a 5-kiloparsec-scale ordered magnetic field with a strength of around 500 μG or lower, oriented parallel to the molecular gas disk. This confirms that such structures can be rapidly formed in galaxies, early in cosmic history. Fig. 1: The magnetic field orientation of the gravitationally lensed galaxy 9io9 at z = 2.553. a–d, ALMA 242 GHz polarimetric observations of the Stokes I, Q and U parameters, and the polarized intensity (PI). The synthetic beam of the observations (1.2″ × 0.9″, θ = 68°) is shown as the red ellipse, lower left. The B field orientation is indicated by white lines shown at the Nyquist sampling, with line lengths proportional to the polarization fraction. e–h, Synthetic polarimetric observations using a constant B field configuration in the source plane. Contours indicate signal to noise: for Stokes I, the contours increase as σI × 23,4,5,…. For Stokes Q and U and for PI, the contours start at 3σ and increase in steps of 1σ. Dec., declination; RA, right ascension.  Fig. 2: Source plane configuration of the magnetic field and lensing model.a, Source plane intensity and field orientation. b, Lensed source plane image. c, Synthetic observations with the synthetic beam size (1.2″ × 0.9″, θ = 68°) indicated by the red ellipse. The B field orientation is indicated by white lines with lengths proportional to the polarization fraction. The median and root mean squared values of the polarization fraction and B field orientation are indicated in the images. The caustics in the source plane and image plane are shown as green and yellow lines, respectively.",
+				"libraryCatalog": "PubScholar",
+				"pages": "483-486",
+				"publicationTitle": "Nature",
+				"url": "https://pubscholar.cn/literatures/8bd0891c723144d4a2a2171aff6da1346ccc6261415f13a2834b4779486970385e61e49e5da6bae88d139b636cab7e48",
 				"attachments": [],
 				"tags": [],
 				"notes": [],


### PR DESCRIPTION
改了很多内容，主要有：
- 元数据`tartget`的正则表达式用了转义表示点`.`
- `LICENSE BLOCK`补充了`Copyright`
- 适配首页推荐的`literatures`类型文章
- 移除`ZU.xpath()`，改用`text()`，详见[官方文档的介绍](https://www.zotero.org/support/dev/translators/coding#web_translators#Saving%20Single%20Items)
- 把按钮点击事件作为异步事件执行等待，修复摘要已展开但无法全部读取的问题
- 为按钮点击增加一个条件判断，修复多次导入导致摘要意外被收起
- （十分潦草地）实现了多条目抓取
- 稍微优化了一下人名清洗头衔的规则
- 增加了一条人名清洗规则，用于去除有人名后面用括号附注的信息（作者单位或名字翻译）
- 年份、卷、期、页改为从导出的引文信息中匹配，因为英文条目不适用原先的`parseMetadata()`
- 移除`id`字段，直接返回文献类型，因为目前我们没有办法利用这个`id`
- 补充了`patent`和`book`的一些字段
- 移除“影响因子”，因为并非所有文章的页面都有这个字段可以抓取，而且已经有Zotero插件可以提供这个信息
- 通过ESLint检测，看Translator的模板似乎更倾向于使用单引号，但我没有改原来使用双引号的内容。