### PR TITLE
将「国家哲学社会科学文献中心」的域名由「.org」改为「.cn」。

### DIFF
--- a/Ncpssd.js
+++ b/Ncpssd.js
@@ -2,7 +2,7 @@
 	"translatorID": "5b731187-04a7-4256-83b4-3f042fa3eaa4",
 	"label": "Ncpssd",
 	"creator": "018<lyb018@gmail.com>,l0o0<linxzh1989@gmail.com>",
-	"target": "^https?://([^/]+\\.)?ncpssd\\.org",
+	"target": "^https?://([^/]+\\.)?ncpssd\\.cn",
 	"minVersion": "3.0",
 	"maxVersion": "",
 	"priority": 100,
@@ -16,7 +16,7 @@
 	***** BEGIN LICENSE BLOCK *****
 
 	Copyright © 2020 018<lyb018@gmail.com>
-	
+
 	This file is part of Zotero.
 
 	Zotero is free software: you can redistribute it and/or modify
@@ -63,7 +63,7 @@ class ID {
 
 	static toUrl(ids) {
 		return encodeURI(
-			'https://www.ncpssd.org/Literature/articleinfo'
+			'https://www.ncpssd.cn/Literature/articleinfo'
 			+ `?id=${ids.id}`
 			+ `&type=${ids.datatype}`
 			+ `&typename=${ids.typename}`
@@ -110,7 +110,7 @@ function getSearchResults(doc, checkOnly) {
 				typename: row.getAttribute('data-type'),
 				barcodenum: row.getAttribute('data-barcodenum')
 			})
-			: `https://www.ncpssd.org${tryMatch(row.getAttribute('onclick'), /\('(.+)'\)/, 1)}`;
+			: `https://www.ncpssd.cn${tryMatch(row.getAttribute('onclick'), /\('(.+)'\)/, 1)}`;
 		if (checkOnly) return true;
 		found = true;
 		items[url] = title;
@@ -226,7 +226,7 @@ async function scrape(url) {
 		};
 	}
 	else {
-		let postUrl = `https://www.ncpssd.org/articleinfoHandler/${ids.datatype == 'Ancient' ? 'getancientbooktable' : 'getjournalarticletable'}`;
+		let postUrl = `https://www.ncpssd.cn/articleinfoHandler/${ids.datatype == 'Ancient' ? 'getancientbooktable' : 'getjournalarticletable'}`;
 		Z.debug(postUrl);
 		json = await requestJSON(
 			postUrl,
@@ -326,191 +326,191 @@ function tryMatch(string, pattern, index = 0) {
 }
 
 /** BEGIN TEST CASES **/
-var testCases = [
-	{
-		"type": "web",
-		"url": "https://www.ncpssd.org/Literature/articlelist?sType=0&search=KElLVEU9IuaWh+WMluiHquS/oSIgT1IgSUtQWVRFPSLmlofljJboh6rkv6EiICBPUiBJS1NUPSLmlofljJboh6rkv6EiIE9SIElLRVQ9IuaWh+WMluiHquS/oSIgT1IgSUtTRT0i5paH5YyW6Ieq5L+hIik=&searchname=6aKY5ZCNL+WFs+mUruivjT0i5paH5YyW6Ieq5L+hIg==&nav=0&ajaxKeys=5paH5YyW6Ieq5L+h",
-		"items": "multiple"
-	},
-	{
-		"type": "web",
-		"url": "https://www.ncpssd.org/index",
-		"items": "multiple"
-	},
-	{
-		"type": "web",
-		"url": "https://www.ncpssd.org/Literature/articleinfo?id=SDJY2023035035&type=journalArticle&datatype=null&typename=%E4%B8%AD%E6%96%87%E6%9C%9F%E5%88%8A%E6%96%87%E7%AB%A0&synUpdateType=undefined&nav=0&barcodenum=&pageUrl=https%253A%252F%252Fwww.ncpssd.org%252FLiterature%252Farticlelist%253Fsearch%253DKElLVEU9IuaWh%252BWMluiHquS%252FoSIgT1IgSUtQWVRFPSLmlofljJboh6rkv6EiICBPUiBJS1NUPSLmlofljJboh6rkv6EiIE9SIElLRVQ9IuaWh%252BWMluiHquS%252FoSIgT1IgSUtTRT0i5paH5YyW6Ieq5L%252BhIikgQU5EIChUWVBFPSLkuK3mlofmnJ%252FliIrmlofnq6AiKQ%253D%253D%2526searchname%253D6aKY5ZCNL%252BWFs%252BmUruivjT0i5paH5YyW6Ieq5L%252BhIiDkuI4gKOexu%252BWeiz3kuK3mlofmnJ%252FliIrmlofnq6Ap%2526nav%253D0",
-		"items": [
-			{
-				"itemType": "journalArticle",
-				"title": "文化自信视角下陶行知外语论著的海外传播",
-				"creators": [
-					{
-						"firstName": "",
-						"lastName": "郭晓菊",
-						"creatorType": "author",
-						"fieldMode": 1
-					}
-				],
-				"date": "2023-12-10",
-				"abstractNote": "陶行知外语论著在世界范围内的传播可被视为中国教育史上的一次现象级传播，同时也是中国教育领域思想与文化的成功输出。作为中国优质教育文化的陶行知外语论著不仅彰显出陶行知教育理念的魅力，也凸显出了中华文化的当代价值及文化自信。基于此，本文在总结陶行知外语论著的传播现状的基础上，阐述了文化自信视角下陶行知外语论著的海外传播。",
-				"issue": "35",
-				"language": "zh-CN",
-				"libraryCatalog": "国家哲学社会科学文献中心",
-				"pages": "103-105",
-				"publicationTitle": "时代教育",
-				"url": "https://www.ncpssd.org/Literature/articleinfo?id=SDJY2023035035&type=journalArticle&typename=%E4%B8%AD%E6%96%87%E6%9C%9F%E5%88%8A%E6%96%87%E7%AB%A0&nav=0+&barcodenum=",
-				"attachments": [],
-				"tags": [
-					{
-						"tag": "外语论著"
-					},
-					{
-						"tag": "文化自信"
-					},
-					{
-						"tag": "陶行知"
-					}
-				],
-				"notes": [],
-				"seeAlso": []
-			}
-		]
-	},
-	{
-		"type": "web",
-		"url": "https://www.ncpssd.org/Literature/articleinfo?id=CASS1039961165&type=eJournalArticle&datatype=journalArticle&typename=%E5%A4%96%E6%96%87%E6%9C%9F%E5%88%8A%E6%96%87%E7%AB%A0&synUpdateType=undefined&nav=0&barcodenum=&pageUrl=https%253A%252F%252Fwww.ncpssd.org%252FLiterature%252Farticlelist%253Fsearch%253DKElLVEU9IuaWh%252BWMluiHquS%252FoSIgT1IgSUtQWVRFPSLmlofljJboh6rkv6EiICBPUiBJS1NUPSLmlofljJboh6rkv6EiIE9SIElLRVQ9IuaWh%252BWMluiHquS%252FoSIgT1IgSUtTRT0i5paH5YyW6Ieq5L%252BhIikgQU5EIChUWVBFPSLlpJbmlofmnJ%252FliIrmlofnq6AiKQ%253D%253D%2526searchname%253D6aKY5ZCNL%252BWFs%252BmUruivjT0i5paH5YyW6Ieq5L%252BhIiDkuI4gKOexu%252BWeiz3lpJbmlofmnJ%252FliIrmlofnq6Ap%2526nav%253D0",
-		"items": [
-			{
-				"itemType": "journalArticle",
-				"title": "文化自信视域下古体诗词在专业教学中的应用研究",
-				"creators": [
-					{
-						"firstName": "",
-						"lastName": "王艺霖",
-						"creatorType": "author",
-						"fieldMode": 1
-					},
-					{
-						"firstName": "",
-						"lastName": "李秀领",
-						"creatorType": "author",
-						"fieldMode": 1
-					},
-					{
-						"firstName": "",
-						"lastName": "王军",
-						"creatorType": "author",
-						"fieldMode": 1
-					},
-					{
-						"firstName": "",
-						"lastName": "张玉明",
-						"creatorType": "author",
-						"fieldMode": 1
-					}
-				],
-				"ISSN": "2160-729X",
-				"abstractNote": "为提升理工科专业知识教育与思政教育的实效，本文以土木工程专业为例，基于“文化自信”理念探讨了将古体诗词与专业课程进行有机融合的新思路：首先创作了一系列表达专业知识的古体诗词，体现了文学性、艺术性与专业性的统一，进而提出了在教学中的具体应用方式(融入课件、用于课内；结合新媒体平台、用于课外)。研究表明，本方式可发掘传统文化的现代价值、提升学生的学习兴趣、感受文化自信、促进人文素养的提升，达到专业教育与传统文化教育的双赢。",
-				"issue": "11",
-				"language": "en-US",
-				"libraryCatalog": "国家哲学社会科学文献中心",
-				"pages": "4294-4299",
-				"url": "https://www.ncpssd.org/Literature/articleinfo?id=CASS1039961165&type=eJournalArticle&typename=%E5%A4%96%E6%96%87%E6%9C%9F%E5%88%8A%E6%96%87%E7%AB%A0&nav=0+&barcodenum=",
-				"volume": "12",
-				"attachments": [],
-				"tags": [
-					{
-						"tag": "古体诗词"
-					},
-					{
-						"tag": "土木工程"
-					},
-					{
-						"tag": "思政"
-					},
-					{
-						"tag": "文化自信"
-					}
-				],
-				"notes": [],
-				"seeAlso": []
-			}
-		]
-	},
-	{
-		"type": "web",
-		"url": "https://www.ncpssd.org/Literature/articleinfo?id=FXJYYJ2023001009&type=collectionsArticle&datatype=journalArticle&typename=%E9%9B%86%E5%88%8A%E6%96%87%E7%AB%A0&synUpdateType=undefined&nav=0&barcodenum=&pageUrl=https%253A%252F%252Fwww.ncpssd.org%252FLiterature%252Farticlelist%253Fsearch%253DKElLVEU9IuaWh%252BWMluiHquS%252FoSIgT1IgSUtQWVRFPSLmlofljJboh6rkv6EiICBPUiBJS1NUPSLmlofljJboh6rkv6EiIE9SIElLRVQ9IuaWh%252BWMluiHquS%252FoSIgT1IgSUtTRT0i5paH5YyW6Ieq5L%252BhIikgQU5EIChUWVBFPSLpm4bliIrmlofnq6AiKQ%253D%253D%2526searchname%253D6aKY5ZCNL%252BWFs%252BmUruivjT0i5paH5YyW6Ieq5L%252BhIiDkuI4gKOexu%252BWeiz3pm4bliIrmlofnq6Ap%2526nav%253D0",
-		"items": [
-			{
-				"itemType": "journalArticle",
-				"title": "文化安全视阈下高校法治人才培养策略研究",
-				"creators": [
-					{
-						"firstName": "",
-						"lastName": "雷艳妮",
-						"creatorType": "author",
-						"fieldMode": 1
-					}
-				],
-				"date": "2023-01-01",
-				"abstractNote": "文化安全事关国家安全和人民幸福，高校法治人才培养与文化安全紧密关联。当前，高校法治人才培养面临诸多文化安全困境，如西方价值观的文化渗透、社会不良文化思潮的冲击、网络新媒体应用过程中的负面影响、高校文化安全教育的不足等。对此，高校法治人才培养应当在保障文化安全的前提下开展。其具体策略有五项：一是将习近平法治思想融入高校法治人才培养，牢固树立思想政治意识；二是将中华优秀传统文化融入高校法治人才培养，着力提升思想道德水平；三是将红色文化融入高校法治人才培养，全面提高思想道德修养；四是加强法律职业道德教育，持续提升职业道德水准；五是加强文化安全教育，坚定文化自觉与文化自信。唯有如此，方能为将我国建成社会主义现代化文化强国提供强大的法治人才保障与智力支持。",
-				"issue": "1",
-				"language": "zh-CN",
-				"libraryCatalog": "国家哲学社会科学文献中心",
-				"pages": "144-157",
-				"publicationTitle": "法学教育研究",
-				"url": "https://www.ncpssd.org/Literature/articleinfo?id=FXJYYJ2023001009&type=collectionsArticle&typename=%E9%9B%86%E5%88%8A%E6%96%87%E7%AB%A0&nav=0+&barcodenum=",
-				"volume": "40",
-				"attachments": [],
-				"tags": [
-					{
-						"tag": "培养策略"
-					},
-					{
-						"tag": "文化安全"
-					},
-					{
-						"tag": "文化自信"
-					},
-					{
-						"tag": "文化自觉"
-					},
-					{
-						"tag": "法治人才"
-					}
-				],
-				"notes": [],
-				"seeAlso": []
-			}
-		]
-	},
-	{
-		"type": "web",
-		"url": "https://www.ncpssd.org/Literature/articleinfo?id=GJ10017&type=Ancient&typename=%E5%8F%A4%E7%B1%8D&nav=5&barcodenum=70050810",
-		"items": [
-			{
-				"itemType": "book",
-				"title": "太平樂圖",
-				"creators": [
-					{
-						"firstName": "",
-						"lastName": "吳之龍",
-						"creatorType": "author",
-						"fieldMode": 1
-					}
-				],
-				"edition": "繪本",
-				"extra": "classify: 子\nremark: 版心：樂闲馆本；浙江民俗畫 \nbarcode: 70050810\nType: classic",
-				"libraryCatalog": "国家哲学社会科学文献中心",
-				"publisher": "樂闲馆",
-				"url": "https://www.ncpssd.org/Literature/articleinfo?id=GJ10017&type=Ancient&typename=%E5%8F%A4%E7%B1%8D&nav=0+&barcodenum=70050810",
-				"attachments": [],
-				"tags": [],
-				"notes": [],
-				"seeAlso": []
-			}
-		]
-	}
+var testCases = [
+	{
+		"type": "web",
+		"url": "https://www.ncpssd.cn/Literature/articlelist?sType=0&search=KElLVEU9IuaWh+WMluiHquS/oSIgT1IgSUtQWVRFPSLmlofljJboh6rkv6EiICBPUiBJS1NUPSLmlofljJboh6rkv6EiIE9SIElLRVQ9IuaWh+WMluiHquS/oSIgT1IgSUtTRT0i5paH5YyW6Ieq5L+hIik=&searchname=6aKY5ZCNL+WFs+mUruivjT0i5paH5YyW6Ieq5L+hIg==&nav=0&ajaxKeys=5paH5YyW6Ieq5L+h",
+		"items": "multiple"
+	},
+	{
+		"type": "web",
+		"url": "https://www.ncpssd.cn/index",
+		"items": "multiple"
+	},
+	{
+		"type": "web",
+		"url": "https://www.ncpssd.cn/Literature/articleinfo?id=SDJY2023035035&type=journalArticle&datatype=null&typename=%E4%B8%AD%E6%96%87%E6%9C%9F%E5%88%8A%E6%96%87%E7%AB%A0&synUpdateType=undefined&nav=0&barcodenum=&pageUrl=https%253A%252F%252Fwww.ncpssd.cn%252FLiterature%252Farticlelist%253Fsearch%253DKElLVEU9IuaWh%252BWMluiHquS%252FoSIgT1IgSUtQWVRFPSLmlofljJboh6rkv6EiICBPUiBJS1NUPSLmlofljJboh6rkv6EiIE9SIElLRVQ9IuaWh%252BWMluiHquS%252FoSIgT1IgSUtTRT0i5paH5YyW6Ieq5L%252BhIikgQU5EIChUWVBFPSLkuK3mlofmnJ%252FliIrmlofnq6AiKQ%253D%253D%2526searchname%253D6aKY5ZCNL%252BWFs%252BmUruivjT0i5paH5YyW6Ieq5L%252BhIiDkuI4gKOexu%252BWeiz3kuK3mlofmnJ%252FliIrmlofnq6Ap%2526nav%253D0",
+		"items": [
+			{
+				"itemType": "journalArticle",
+				"title": "文化自信视角下陶行知外语论著的海外传播",
+				"creators": [
+					{
+						"firstName": "",
+						"lastName": "郭晓菊",
+						"creatorType": "author",
+						"fieldMode": 1
+					}
+				],
+				"date": "2023-12-10",
+				"abstractNote": "陶行知外语论著在世界范围内的传播可被视为中国教育史上的一次现象级传播，同时也是中国教育领域思想与文化的成功输出。作为中国优质教育文化的陶行知外语论著不仅彰显出陶行知教育理念的魅力，也凸显出了中华文化的当代价值及文化自信。基于此，本文在总结陶行知外语论著的传播现状的基础上，阐述了文化自信视角下陶行知外语论著的海外传播。",
+				"issue": "35",
+				"language": "zh-CN",
+				"libraryCatalog": "国家哲学社会科学文献中心",
+				"pages": "103-105",
+				"publicationTitle": "时代教育",
+				"url": "https://www.ncpssd.cn/Literature/articleinfo?id=SDJY2023035035&type=journalArticle&typename=%E4%B8%AD%E6%96%87%E6%9C%9F%E5%88%8A%E6%96%87%E7%AB%A0&nav=0+&barcodenum=",
+				"attachments": [],
+				"tags": [
+					{
+						"tag": "外语论著"
+					},
+					{
+						"tag": "文化自信"
+					},
+					{
+						"tag": "陶行知"
+					}
+				],
+				"notes": [],
+				"seeAlso": []
+			}
+		]
+	},
+	{
+		"type": "web",
+		"url": "https://www.ncpssd.cn/Literature/articleinfo?id=CASS1039961165&type=eJournalArticle&datatype=journalArticle&typename=%E5%A4%96%E6%96%87%E6%9C%9F%E5%88%8A%E6%96%87%E7%AB%A0&synUpdateType=undefined&nav=0&barcodenum=&pageUrl=https%253A%252F%252Fwww.ncpssd.cn%252FLiterature%252Farticlelist%253Fsearch%253DKElLVEU9IuaWh%252BWMluiHquS%252FoSIgT1IgSUtQWVRFPSLmlofljJboh6rkv6EiICBPUiBJS1NUPSLmlofljJboh6rkv6EiIE9SIElLRVQ9IuaWh%252BWMluiHquS%252FoSIgT1IgSUtTRT0i5paH5YyW6Ieq5L%252BhIikgQU5EIChUWVBFPSLlpJbmlofmnJ%252FliIrmlofnq6AiKQ%253D%253D%2526searchname%253D6aKY5ZCNL%252BWFs%252BmUruivjT0i5paH5YyW6Ieq5L%252BhIiDkuI4gKOexu%252BWeiz3lpJbmlofmnJ%252FliIrmlofnq6Ap%2526nav%253D0",
+		"items": [
+			{
+				"itemType": "journalArticle",
+				"title": "文化自信视域下古体诗词在专业教学中的应用研究",
+				"creators": [
+					{
+						"firstName": "",
+						"lastName": "王艺霖",
+						"creatorType": "author",
+						"fieldMode": 1
+					},
+					{
+						"firstName": "",
+						"lastName": "李秀领",
+						"creatorType": "author",
+						"fieldMode": 1
+					},
+					{
+						"firstName": "",
+						"lastName": "王军",
+						"creatorType": "author",
+						"fieldMode": 1
+					},
+					{
+						"firstName": "",
+						"lastName": "张玉明",
+						"creatorType": "author",
+						"fieldMode": 1
+					}
+				],
+				"ISSN": "2160-729X",
+				"abstractNote": "为提升理工科专业知识教育与思政教育的实效，本文以土木工程专业为例，基于“文化自信”理念探讨了将古体诗词与专业课程进行有机融合的新思路：首先创作了一系列表达专业知识的古体诗词，体现了文学性、艺术性与专业性的统一，进而提出了在教学中的具体应用方式(融入课件、用于课内；结合新媒体平台、用于课外)。研究表明，本方式可发掘传统文化的现代价值、提升学生的学习兴趣、感受文化自信、促进人文素养的提升，达到专业教育与传统文化教育的双赢。",
+				"issue": "11",
+				"language": "en-US",
+				"libraryCatalog": "国家哲学社会科学文献中心",
+				"pages": "4294-4299",
+				"url": "https://www.ncpssd.cn/Literature/articleinfo?id=CASS1039961165&type=eJournalArticle&typename=%E5%A4%96%E6%96%87%E6%9C%9F%E5%88%8A%E6%96%87%E7%AB%A0&nav=0+&barcodenum=",
+				"volume": "12",
+				"attachments": [],
+				"tags": [
+					{
+						"tag": "古体诗词"
+					},
+					{
+						"tag": "土木工程"
+					},
+					{
+						"tag": "思政"
+					},
+					{
+						"tag": "文化自信"
+					}
+				],
+				"notes": [],
+				"seeAlso": []
+			}
+		]
+	},
+	{
+		"type": "web",
+		"url": "https://www.ncpssd.cn/Literature/articleinfo?id=FXJYYJ2023001009&type=collectionsArticle&datatype=journalArticle&typename=%E9%9B%86%E5%88%8A%E6%96%87%E7%AB%A0&synUpdateType=undefined&nav=0&barcodenum=&pageUrl=https%253A%252F%252Fwww.ncpssd.cn%252FLiterature%252Farticlelist%253Fsearch%253DKElLVEU9IuaWh%252BWMluiHquS%252FoSIgT1IgSUtQWVRFPSLmlofljJboh6rkv6EiICBPUiBJS1NUPSLmlofljJboh6rkv6EiIE9SIElLRVQ9IuaWh%252BWMluiHquS%252FoSIgT1IgSUtTRT0i5paH5YyW6Ieq5L%252BhIikgQU5EIChUWVBFPSLpm4bliIrmlofnq6AiKQ%253D%253D%2526searchname%253D6aKY5ZCNL%252BWFs%252BmUruivjT0i5paH5YyW6Ieq5L%252BhIiDkuI4gKOexu%252BWeiz3pm4bliIrmlofnq6Ap%2526nav%253D0",
+		"items": [
+			{
+				"itemType": "journalArticle",
+				"title": "文化安全视阈下高校法治人才培养策略研究",
+				"creators": [
+					{
+						"firstName": "",
+						"lastName": "雷艳妮",
+						"creatorType": "author",
+						"fieldMode": 1
+					}
+				],
+				"date": "2023-01-01",
+				"abstractNote": "文化安全事关国家安全和人民幸福，高校法治人才培养与文化安全紧密关联。当前，高校法治人才培养面临诸多文化安全困境，如西方价值观的文化渗透、社会不良文化思潮的冲击、网络新媒体应用过程中的负面影响、高校文化安全教育的不足等。对此，高校法治人才培养应当在保障文化安全的前提下开展。其具体策略有五项：一是将习近平法治思想融入高校法治人才培养，牢固树立思想政治意识；二是将中华优秀传统文化融入高校法治人才培养，着力提升思想道德水平；三是将红色文化融入高校法治人才培养，全面提高思想道德修养；四是加强法律职业道德教育，持续提升职业道德水准；五是加强文化安全教育，坚定文化自觉与文化自信。唯有如此，方能为将我国建成社会主义现代化文化强国提供强大的法治人才保障与智力支持。",
+				"issue": "1",
+				"language": "zh-CN",
+				"libraryCatalog": "国家哲学社会科学文献中心",
+				"pages": "144-157",
+				"publicationTitle": "法学教育研究",
+				"url": "https://www.ncpssd.cn/Literature/articleinfo?id=FXJYYJ2023001009&type=collectionsArticle&typename=%E9%9B%86%E5%88%8A%E6%96%87%E7%AB%A0&nav=0+&barcodenum=",
+				"volume": "40",
+				"attachments": [],
+				"tags": [
+					{
+						"tag": "培养策略"
+					},
+					{
+						"tag": "文化安全"
+					},
+					{
+						"tag": "文化自信"
+					},
+					{
+						"tag": "文化自觉"
+					},
+					{
+						"tag": "法治人才"
+					}
+				],
+				"notes": [],
+				"seeAlso": []
+			}
+		]
+	},
+	{
+		"type": "web",
+		"url": "https://www.ncpssd.cn/Literature/articleinfo?id=GJ10017&type=Ancient&typename=%E5%8F%A4%E7%B1%8D&nav=5&barcodenum=70050810",
+		"items": [
+			{
+				"itemType": "book",
+				"title": "太平樂圖",
+				"creators": [
+					{
+						"firstName": "",
+						"lastName": "吳之龍",
+						"creatorType": "author",
+						"fieldMode": 1
+					}
+				],
+				"edition": "繪本",
+				"extra": "classify: 子\nremark: 版心：樂闲馆本；浙江民俗畫 \nbarcode: 70050810\nType: classic",
+				"libraryCatalog": "国家哲学社会科学文献中心",
+				"publisher": "樂闲馆",
+				"url": "https://www.ncpssd.cn/Literature/articleinfo?id=GJ10017&type=Ancient&typename=%E5%8F%A4%E7%B1%8D&nav=0+&barcodenum=70050810",
+				"attachments": [],
+				"tags": [],
+				"notes": [],
+				"seeAlso": []
+			}
+		]
+	}
 ]
 /** END TEST CASES **/


### PR DESCRIPTION
将「国家哲学社会科学文献中心」的域名由「.org」改为「.cn」。