### PR TITLE
修复 读秀bookurl不可访问

### DIFF
--- a/Duxiu.js
+++ b/Duxiu.js
@@ -222,7 +222,7 @@ async function scrape(doc, url = doc.location.href) {
 			newItem.number = getField('标准号').replace('-', '—');
 			break;
 	}
-	newItem.url = tryMatch(url, /^.+dxNumber=\w+/i) || url;
+	newItem.url = tryMatch(url, /^.+dxNumber=\w+&d=\w+&fenle=\d+/i) || url;
 	extra.set('original-title', ZU.capitalizeTitle(getField(['外文题名', '标准英文名'])), true);
 	extra.set('genre', getField('专利类型'), true);
 	extra.set('price', getField('原书定价'));


### PR DESCRIPTION
补充正则d值、fenlei值匹配，保证可bookurl可访问性

bookDetail.jsp?dxNumber=000030342974&d=7A85DF1EDEFBBEEA4E76958392F25632&fenlei=1605040302