### PR TITLE
[codex] fix CNKI fallback metadata handling

### DIFF
--- a/CNKI Oversea.js
+++ b/CNKI Oversea.js
@@ -244,7 +244,7 @@ async function scrapeMain(doc, url) {
 			+ `&filename=${params.filename}`;
 	}
 	newItem.language = detectLanguage(params.dbcode);
-	setExtra(newItem, 'CNKICite', innerText(doc, '#RefAuthorArea .num') || innerText(doc, '#citations+span').substring(1, -1));
+	setExtra(newItem, 'CNKICite', innerText(doc, '#RefAuthorArea .num') || innerText(doc, '#citations+span').slice(1, -1));
 	setExtra(newItem, 'dbcode', params.dbcode);
 	setExtra(newItem, 'dbname', params.dbname);
 	setExtra(newItem, 'filename', params.filename);

--- a/CNKI Oversea.js
+++ b/CNKI Oversea.js
@@ -244,10 +244,10 @@ async function scrapeMain(doc, url) {
 			+ `&filename=${params.filename}`;
 	}
 	newItem.language = detectLanguage(params.dbcode);
-	setExtra('CNKICite', innerText(doc, '#RefAuthorArea .num') || innerText(doc, '#citations+span').substring(1, -1));
-	setExtra('dbcode', params.dbcode);
-	setExtra('dbname', params.dbname);
-	setExtra('filename', params.filename);
+	setExtra(newItem, 'CNKICite', innerText(doc, '#RefAuthorArea .num') || innerText(doc, '#citations+span').substring(1, -1));
+	setExtra(newItem, 'dbcode', params.dbcode);
+	setExtra(newItem, 'dbname', params.dbname);
+	setExtra(newItem, 'filename', params.filename);
 	switch (itemType) {
 		case 'journalArticle': {
 			const pubInfo = ZU.trimInternal(innerText(doc, '.top-tip'));

--- a/CNKI Scholar.js
+++ b/CNKI Scholar.js
@@ -116,8 +116,9 @@ async function scrape(doc, url = doc.location.href) {
 			newItem.url = url;
 		}
 		newItem.language = {
+			Chinese: 'zh-CN',
 			English: 'en-US',
-		}[data.articleeLanguage] ?? 'en-US';
+		}[data.articleLanguage] ?? 'en-US';
 		switch (newItem.itemType) {
 			case 'journalArticle':
 				newItem.publicationTitle = data.journal;
@@ -170,11 +171,11 @@ async function scrape(doc, url = doc.location.href) {
 							}
 						);
 					}
-					catch (error) {
-						bookJson.articleAuthor?.forEach((name) => {
-							newItem.creators.push(ZU.cleanAuthor(name, 'bookAuthor'));
-						});
-					}
+						catch (error) {
+							bookData.articleAuthor?.forEach((name) => {
+								newItem.creators.push(ZU.cleanAuthor(name, 'bookAuthor'));
+							});
+						}
 				}
 				break;
 			}
@@ -203,9 +204,9 @@ async function scrape(doc, url = doc.location.href) {
 		data.articleAuthor?.forEach((name) => {
 			newItem.creators.push(ZU.cleanAuthor(name, 'author'));
 		});
-		data.articleKeywords?.forEach((word) => {
-			newItem.tags(word.trim());
-		});
+			data.articleKeywords?.forEach((word) => {
+				newItem.tags.push(word.trim());
+			});
 		newItem.complete();
 	}
 }

--- a/CNKI Scholar.js
+++ b/CNKI Scholar.js
@@ -171,11 +171,11 @@ async function scrape(doc, url = doc.location.href) {
 							}
 						);
 					}
-						catch (error) {
-							bookData.articleAuthor?.forEach((name) => {
-								newItem.creators.push(ZU.cleanAuthor(name, 'bookAuthor'));
-							});
-						}
+					catch (error) {
+						bookData.articleAuthor?.forEach((name) => {
+							newItem.creators.push(ZU.cleanAuthor(name, 'bookAuthor'));
+						});
+					}
 				}
 				break;
 			}
@@ -204,9 +204,9 @@ async function scrape(doc, url = doc.location.href) {
 		data.articleAuthor?.forEach((name) => {
 			newItem.creators.push(ZU.cleanAuthor(name, 'author'));
 		});
-			data.articleKeywords?.forEach((word) => {
-				newItem.tags.push(word.trim());
-			});
+		data.articleKeywords?.forEach((word) => {
+			newItem.tags.push(word.trim());
+		});
 		newItem.complete();
 	}
 }

--- a/CNKI.js
+++ b/CNKI.js
@@ -277,7 +277,7 @@ async function scrapeMain(doc, url) {
 			+ `&filename=${params.filename}`;
 	}
 	newItem.language = detectLanguage(params.dbcode);
-	setExtra(newItem, 'CNKICite', innerText(doc, '#RefAuthorArea .num') || innerText(doc, '#citations+span').substring(1, -1));
+	setExtra(newItem, 'CNKICite', innerText(doc, '#RefAuthorArea .num') || innerText(doc, '#citations+span').slice(1, -1));
 	setExtra(newItem, 'dbcode', params.dbcode);
 	setExtra(newItem, 'dbname', params.dbname);
 	setExtra(newItem, 'filename', params.filename);

--- a/CNKI.js
+++ b/CNKI.js
@@ -277,10 +277,10 @@ async function scrapeMain(doc, url) {
 			+ `&filename=${params.filename}`;
 	}
 	newItem.language = detectLanguage(params.dbcode);
-	setExtra('CNKICite', innerText(doc, '#RefAuthorArea .num') || innerText(doc, '#citations+span').substring(1, -1));
-	setExtra('dbcode', params.dbcode);
-	setExtra('dbname', params.dbname);
-	setExtra('filename', params.filename);
+	setExtra(newItem, 'CNKICite', innerText(doc, '#RefAuthorArea .num') || innerText(doc, '#citations+span').substring(1, -1));
+	setExtra(newItem, 'dbcode', params.dbcode);
+	setExtra(newItem, 'dbname', params.dbname);
+	setExtra(newItem, 'filename', params.filename);
 	switch (itemType) {
 		case 'journalArticle': {
 			const pubInfo = ZU.trimInternal(innerText(doc, '.top-tip'));


### PR DESCRIPTION
Fixes #887

## What changed
- fixed the CNKI Scholar fallback path so keyword extraction no longer crashes imports
- corrected Scholar fallback language mapping and preserved parent-book authors for book sections
- restored missing extra metadata fields in both `CNKI.js` and `CNKI Oversea.js`

## Why
These fixes address review findings in the CNKI translators where fallback scraping could either fail outright or silently produce incomplete metadata.

## Root cause
- `newItem.tags` was called like a function instead of pushing onto the tags array
- the Scholar fallback read a misspelled language field
- the book-section rescue path read authors from the wrong object
- `setExtra()` was called without passing the target item in the mainland and oversea translators

## Impact
- fallback imports from CNKI Scholar no longer fail when keywords are present
- fallback imports now preserve the correct language and more complete book metadata
- CNKI items again store provenance fields such as `CNKICite`, `dbcode`, `dbname`, and `filename`

## Validation
- installed project dependencies with `npm ci`
- ran `npm test`
- note: `npm test` still reports many pre-existing repo-wide lint errors in unrelated files, but these touched files were committed cleanly and no new lint issue from this diff was observed during the targeted review
