### PR TITLE
fix(CNKI): add missing newItem argument in setExtra call for patent case

### DIFF
--- a/CNKI.js
+++ b/CNKI.js
@@ -452,7 +452,7 @@ async function scrapeMain(doc, url) {
 			newItem.filingDate = data('申请日');
 			newItem.issueDate = data('授权公告日');
 			newItem.rights = ZU.trimInternal(innerText(doc, '.claim > h5 + div'));
-			setExtra('Genre', data('专利类型'));
+			setExtra(newItem, 'Genre', data('专利类型'));
 			data('发明人', true)
 				.querySelectorAll('a')
 				.forEach((elm) => {


### PR DESCRIPTION
## 描述

修复 `CNKI.js` 中处理专利（patent）条目时的一个运行时错误。

在 `patent` 分支中，`setExtra('Genre', data('专利类型'))` 调用缺少了第一个参数 `newItem`，导致 `setExtra` 函数内部无法正确设置 Extra 字段，可能引发运行时异常。

## 变更

- `CNKI.js`: 将 `setExtra('Genre', ...)` 修正为 `setExtra(newItem, 'Genre', ...)`

## 相关问题

该问题在代码审查中发现，详见 #review-discussion