### PR TITLE
fix(E-Tiller): fix enCreator variable name typo and download extra field bug

### DIFF
--- a/E-Tiller.js
+++ b/E-Tiller.js
@@ -126,10 +126,10 @@ async function scrapeMeta(doc, url = doc.location.href) {
 			.map(name => cleanAuthor(name));
 		const creatorsExt = [];
 		zhCreators.forEach((creator, i) => {
-			const enCcreator = enCreators[i];
+			const enCreator = enCreators[i];
 			item.creators.push(creator);
 			if (enCreator) {
-				const enCreatorStr = `${enCcreator.lastName} || ${enCcreator.firstName}`;
+				const enCreatorStr = `${enCreator.lastName} || ${enCreator.firstName}`;
 				extra.push('original-creator', enCreatorStr, true);
 				creatorsExt.push({
 					firstName: creator.firstName,
@@ -197,7 +197,7 @@ async function scrapeText(doc, url = doc.location.href) {
 	const urlElm = doc.querySelector('a#URL');
 	urlElm && (newItem.url = urlElm.href);
 	extra.set('view', text(doc, '#ClickNum'));
-	extra.set('download', '#PDFClickNum');
+	extra.set('download', text(doc, '#PDFClickNum'));
 	newItem.extra = extra.toString();
 	let creators = doc.querySelector('#Author td > a[href*="field=author"]')
 		? Array.from(doc.querySelectorAll('#Author td > a[href*="field=author"]')).map(elm => ZU.trimInternal(elm.textContent))


### PR DESCRIPTION
## 描述

修复 E-Tiller.js 中的两个运行时错误：

### 1. 变量名错误
`zhCreators.forEach` 回调中定义的是 `enCcreator`（多了一个 'c'），但后续使用的是 `enCreator`（未定义），导致 ESLint 报 `no-undef` 错误，且在实际运行中会访问 `undefined` 的属性而崩溃。

### 2. extra.set 参数错误
`extra.set('download', '#PDFClickNum')` 的第二个参数是一个 CSS 选择器字符串字面量，而不是实际的值。根据上下文，应改为 `text(doc, '#PDFClickNum')` 以获取实际内容，与上一行 `extra.set('view', text(doc, '#ClickNum'))` 保持一致。

## 变更

- `E-Tiller.js`: 修复变量名 `enCcreator` → `enCreator`
- `E-Tiller.js`: 修复 `extra.set('download', ...)` 参数