### PR TITLE
style: run eslint --fix and fix auto-fixable code quality issues

### DIFF
--- a/CCPINFO.js
+++ b/CCPINFO.js
@@ -129,8 +129,8 @@ async function scrape(doc, url = doc.location.href) {
 	const newItem = new Zotero.Item('book');
 	const data = getLabeledData(
 		doc.querySelectorAll('.book_intro .book_con > :where(.fr, .fl)'),
-		(row) => text(row, '.fl:first-child').replace(/：$/, ''),
-		(row) => row.querySelector('.val_txt'),
+		row => text(row, '.fl:first-child').replace(/：$/, ''),
+		row => row.querySelector('.val_txt'),
 		doc.createElement('div')
 	);
 	newItem.title = text(doc, '.book_intro > h2 > span');
@@ -205,8 +205,8 @@ function getLabeledData(rows, labelGetter, dataGetter, defaultElm) {
 			for (const label of labels) {
 				const result = data(label, element);
 				if (
-					(element && /\S/.test(result.textContent)) ||
-					(!element && /\S/.test(result))) {
+					(element && /\S/.test(result.textContent))
+					|| (!element && /\S/.test(result))) {
 					return result;
 				}
 			}

--- a/CNKI e-Books.js
+++ b/CNKI e-Books.js
@@ -142,8 +142,8 @@ function getLabeledData(rows, labelGetter, dataGetter, defaultElm) {
 			for (const label of labels) {
 				const result = data(label, element);
 				if (
-					(element && /\S/.test(result.textContent)) ||
-					(!element && /\S/.test(result))) {
+					(element && /\S/.test(result.textContent))
+					|| (!element && /\S/.test(result))) {
 					return result;
 				}
 			}

--- a/CNKI.js
+++ b/CNKI.js
@@ -228,7 +228,8 @@ async function scrapeMain(doc, url) {
 	let rows = [];
 	try {
 		rows = doc.querySelectorAll('.main .container :has(>[class^="rowtit"])');
-	} catch (e) {
+	}
+	catch (e) {
 		// Compatibility with old browser that doesn't support `:has()` selector
 		const titles = doc.querySelectorAll('.main .container [class^="rowtit"]');
 		const uniqueRows = new Set();

--- a/CQVIP Qikan.js
+++ b/CQVIP Qikan.js
@@ -200,15 +200,15 @@ function cleanAuthor(name) {
 	return creator;
 }
 
-async function getPDF(id, key) {
-	const postUrl = '/Qikan/Article/ArticleDown';
-	const postData = `id=${id}&info=${key}&ts=${(new Date).getTime()}`;
-	const respond = await requestJSON(postUrl, {
-		method: 'POST',
-		body: postData
-	});
-	return respond.url;
-}
+// async function getPDF(id, key) {
+// 	const postUrl = '/Qikan/Article/ArticleDown';
+// 	const postData = `id=${id}&info=${key}&ts=${(new Date).getTime()}`;
+// 	const respond = await requestJSON(postUrl, {
+// 		method: 'POST',
+// 		body: postData
+// 	});
+// 	return respond.url;
+// }
 
 function richTextTitle(item, doc) {
 	let title = doc.querySelector('.article-title > h1');

--- a/E-Tiller.js
+++ b/E-Tiller.js
@@ -126,10 +126,10 @@ async function scrapeMeta(doc, url = doc.location.href) {
 			.map(name => cleanAuthor(name));
 		const creatorsExt = [];
 		zhCreators.forEach((creator, i) => {
-			const enCcreator = enCreators[i];
+			const enCreator = enCreators[i];
 			item.creators.push(creator);
 			if (enCreator) {
-				const enCreatorStr = `${enCcreator.lastName} || ${enCcreator.firstName}`;
+				const enCreatorStr = `${enCreator.lastName} || ${enCreator.firstName}`;
 				extra.push('original-creator', enCreatorStr, true);
 				creatorsExt.push({
 					firstName: creator.firstName,

--- a/GFSOSO.js
+++ b/GFSOSO.js
@@ -13,7 +13,32 @@
 }
 
 // attr()/text() v2
-function attr(docOrElem,selector,attr,index){var elem=index?docOrElem.querySelectorAll(selector).item(index):docOrElem.querySelector(selector);return elem?elem.getAttribute(attr):null;}function text(docOrElem,selector,index){var elem=index?docOrElem.querySelectorAll(selector).item(index):docOrElem.querySelector(selector);return elem?elem.textContent:null;}
+
+
+/*
+	***** BEGIN LICENSE BLOCK *****
+
+	Copyright © 2020-2026 西班牙馅饼, Simon Kornblith, Frank Bennett, Aurimas Vinckevicius
+
+	This file is part of Zotero.
+
+	Zotero is free software: you can redistribute it and/or modify
+	it under the terms of the GNU Affero General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	Zotero is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+	GNU Affero General Public License for more details.
+
+	You should have received a copy of the GNU Affero General Public License
+	along with Zotero. If not, see <http://www.gnu.org/licenses/>.
+
+	***** END LICENSE BLOCK *****
+*/
+
+// `attr` and `text` are built-in global functions provided by Zotero, so we don't redefine them here
 
 
 function detectWeb(doc, url) {
@@ -21,11 +46,12 @@ function detectWeb(doc, url) {
 	 * e.g. url of "how cited" page:
 	 *   http://scholar.google.co.jp/scholar_case?about=1101424605047973909&q=kelo&hl=en&as_sdt=2002
 	 */
-	if (url.indexOf('/scholar_case?') != -1
-		&& url.indexOf('about=') == -1
+	if (url.contains('/scholar_case?')
+		&& !(url.contains('about='))
 	) {
 		return "case";
-	} else if (url.indexOf('/citations?') != -1) {
+	}
+	else if (url.contains('/citations?')) {
 		if (getProfileResults(doc, true)) {
 			return "multiple";
 		}
@@ -33,14 +59,16 @@ function detectWeb(doc, url) {
 		//individual saved citation
 		var link = ZU.xpathText(doc, '//a[@class="gsc_vcd_title_link"]/@href');
 		if (!link) return;
-		if (link.indexOf('/scholar_case?') != -1) {
+		if (link.contains('/scholar_case?')) {
 			return 'case';
-		} else {
+		}
+		else {
 			//Can't distinguish book from journalArticle
 			//Both have "Journal" fields
 			return 'journalArticle';
 		}
-	} else if (getSearchResults(doc, true)) {
+	}
+	else if (getSearchResults(doc, true)) {
 		return "multiple";
 	}
 }
@@ -50,10 +78,10 @@ function getSearchResults(doc, checkOnly, itemInfo) {
 	var items = {};
 	var found = false;
 	var rows = doc.querySelectorAll('.gs_r[data-cid]');
-	for (var i=0; i<rows.length; i++) {
+	for (var i = 0; i < rows.length; i++) {
 		var href = rows[i].dataset.cid;
 		var title = text(rows[i], '.gs_rt');
-		var url = rows[i].querySelector('a[id]').href
+		var url = rows[i].querySelector('a[id]').href;
 		if (!href || !title) continue;
 		if (checkOnly) return true;
 		found = true;
@@ -68,7 +96,7 @@ function getProfileResults(doc, checkOnly, itemInfo) {
 	var items = {};
 	var found = false;
 	var rows = doc.querySelectorAll('a.gsc_a_at');
-	for (var i=0; i<rows.length; i++) {
+	for (var i = 0; i < rows.length; i++) {
 		var href = rows[i].dataset.href;
 		var title = rows[i].textContent;
 		if (!href || !title) continue;
@@ -97,12 +125,13 @@ function doWeb(doc, url) {
 				//here it is enough to know the ids and we can call scrape directly
 				scrape(doc, ids, itemInfo);
 			});
-		} else if (getProfileResults(doc, true)) {
+		}
+		else if (getProfileResults(doc, true)) {
 			Zotero.selectItems(getProfileResults(doc, false, itemInfo), function (items) {
 				if (!items) {
 					return true;
 				}
-				var articles  = {}
+				var articles = {};
 				for (var i in items) {
 					articles.push(i);
 				}
@@ -110,7 +139,8 @@ function doWeb(doc, url) {
 				ZU.processDocuments(articles, scrape);
 			});
 		}
-	} else {
+	}
+	else {
 		//e.g. https://scholar.google.de/citations?view_op=view_citation&hl=de&user=INQwsQkAAAAJ&citation_for_view=INQwsQkAAAAJ:u5HHmVD_uO8C
 		scrape(doc, url, type);
 	}
@@ -120,41 +150,41 @@ function doWeb(doc, url) {
 function scrape(doc, idsOrUrl, type) {
 	if (Array.isArray(idsOrUrl)) {
 		scrapeIds(doc, idsOrUrl, type);
-	} else {
-		if (type && type=="case") {
-			scrapeCase(doc, idsOrUrl);
-		} else {
-			var related = ZU.xpathText(doc, '//a[contains(@href, "q=related:")]/@href');
-			if (!related) {
-				throw new Error("Could not locate related URL");
-			}
-			var itemID = related.match(/=related:([^:]+):/);
-			if (itemID) {
-				scrapeIds(doc, [itemID[1]]);
-			} else {
-				Z.debug("Can't find itemID. related URL is " + related);
-				throw new Error("Cannot extract itemID from related link");
-			}
+	}
+	else if (type && type == "case") {
+		scrapeCase(doc, idsOrUrl);
+	}
+	else {
+		var related = ZU.xpathText(doc, '//a[contains(@href, "q=related:")]/@href');
+		if (!related) {
+			throw new Error("Could not locate related URL");
+		}
+		var itemID = related.match(/=related:([^:]+):/);
+		if (itemID) {
+			scrapeIds(doc, [itemID[1]]);
+		}
+		else {
+			Z.debug("Can't find itemID. related URL is " + related);
+			throw new Error("Cannot extract itemID from related link");
 		}
 	}
-	
 }
 
 
 function scrapeIds(doc, ids, itemInfo) {
-	for (let i=0; i<ids.length; i++) {
+	for (let i = 0; i < ids.length; i++) {
 		// We need here 'let' to access id later in the nested functions
 		let context = doc.querySelector('.gs_r[data-cid="' + ids[i] + '"]');
-		if (!context && ids.length==1) context = doc;
+		if (!context && ids.length == 1) context = doc;
 		var citeUrl = '/scholar?q=info:' + ids[i] + ':scholar.google.com/&output=cite&scirp=1';
 		// For 'My Library' we check the search field at the top
 		// and then in these cases change the citeUrl accordingly.
-		var scilib = attr(doc, '#gs_hdr_frm input[name="scilib"]', 'value')
-		if (scilib && scilib==1) {
+		var scilib = attr(doc, '#gs_hdr_frm input[name="scilib"]', 'value');
+		if (scilib && scilib == 1) {
 			var citeUrl = '/scholar?scila=' + ids[i] + '&output=cite&scirp=1';
 		}
 		var idx = i;
-		ZU.doGet(citeUrl, function(citePage) {
+		ZU.doGet(citeUrl, function (citePage) {
 			var m = citePage.match(/href="((https?:\/\/[a-z\.]*)?\/scholar.bib\?[^"]+)/);
 			if (!m) {
 				//Saved lists and possibly other places have different formats for BibTeX URLs
@@ -165,25 +195,25 @@ function scrapeIds(doc, ids, itemInfo) {
 				var msg = "Could not find BibTeX URL";
 				var title = citePage.match(/<title>(.*?)<\/title>/i);
 				if (title) {
-					if (title) msg += ' Got page with title "' + title[1] +'"';
+					if (title) msg += ' Got page with title "' + title[1] + '"';
 				}
 				throw new Error(msg);
 			}
 			var bibUrl = ZU.unescapeHTML(m[1]);
-			var idx = i
-			ZU.doGet(bibUrl, function(bibtex) {
+			var idx = i;
+			ZU.doGet(bibUrl, function (bibtex) {
 				var translator = Zotero.loadTranslator("import");
 				translator.setTranslator("9cb70025-a888-4a29-a210-93ec52da40d4");
 				translator.setString(bibtex);
-				translator.setHandler("itemDone", function(obj, item) {
+				translator.setHandler("itemDone", function (obj, item) {
 					//these two variables are extracted from the context
 					var titleLink = attr(context, 'h3 a, #gsc_vcd_title a', 'href');
 					var secondLine = text(context, '.gs_a') || '';
 					//case are not recognized and can be characterized by the
 					//titleLink, or that the second line starts with a number
 					//e.g. 1 Cr. 137 - Supreme Court, 1803
-					if ((titleLink && titleLink.indexOf('/scholar_case?')>-1) || 
-						secondLine && ['0', '1', '2', '3', '4', '5', '6', '7', '8', '9'].indexOf(secondLine[0])>-1) {
+					if ((titleLink && titleLink.contains('/scholar_case?'))
+						|| secondLine && ['0', '1', '2', '3', '4', '5', '6', '7', '8', '9'].contains(secondLine[0])) {
 						item.itemType = "case";
 						item.caseName = item.title;
 						item.reporter = item.publicationTitle;
@@ -193,10 +223,10 @@ function scrapeIds(doc, ids, itemInfo) {
 					}
 					//patents are not recognized but are easily detected
 					//by the titleLink or second line
-					if ((titleLink && titleLink.indexOf('google.com/patents/')>-1) || secondLine.indexOf('Google Patents')>-1) {
+					if ((titleLink && titleLink.contains('google.com/patents/')) || secondLine.contains('Google Patents')) {
 						item.itemType = "patent";
 						//authors are inventors
-						for (var i=0, n=item.creators.length; i<n; i++) {
+						for (var i = 0, n = item.creators.length; i < n; i++) {
 							item.creators[i].creatorType = 'inventor';
 						}
 						//country and patent number
@@ -216,20 +246,20 @@ function scrapeIds(doc, ids, itemInfo) {
 					
 					//delete "others" as author
 					if (item.creators.length) {
-						var lastCreatorIndex = item.creators.length-1,
+						var lastCreatorIndex = item.creators.length - 1,
 							lastCreator = item.creators[lastCreatorIndex];
-						if (lastCreator.lastName === "others" && (lastCreator.fieldMode === 1 ||lastCreator.firstName === "")) {
+						if (lastCreator.lastName === "others" && (lastCreator.fieldMode === 1 || lastCreator.firstName === "")) {
 							item.creators.splice(lastCreatorIndex, 1);
 						}
 					}
 					
 					//clean author names
-					for (var j=0, m=item.creators.length; j<m; j++) {
+					for (var j = 0, m = item.creators.length; j < m; j++) {
 						if (!item.creators[j].firstName) continue;
 			
 						item.creators[j] = ZU.cleanAuthor(
-							item.creators[j].lastName + ', ' +
-								item.creators[j].firstName,
+							item.creators[j].lastName + ', '
+								+ item.creators[j].firstName,
 							item.creators[j].creatorType,
 							true);
 					}
@@ -246,11 +276,11 @@ function scrapeIds(doc, ids, itemInfo) {
 						var m = documentLinkTitle.match(/^\[(\w+)\]/);
 						if (m) {
 							var mimeTypes = {
-								'PDF': 'application/pdf',
-								'DOC': 'application/msword',
-								'HTML': 'text/html'
+								PDF: 'application/pdf',
+								DOC: 'application/msword',
+								HTML: 'text/html'
 							};
-							if (Object.keys(mimeTypes).indexOf(m[1].toUpperCase())>-1) {
+							if (Object.keys(mimeTypes).contains(m[1].toUpperCase())) {
 								attachment.mimeType = mimeTypes[m[1]];
 							}
 						}
@@ -292,7 +322,7 @@ var scrapeCase = function (doc, url) {
 	// Citelet is identified by
 	// id="gsl_reference"
 	var refFrag = doc.evaluate('//div[@id="gsl_reference"] | //div[@id="gs_reference"]',
-					doc, null, XPathResult.ANY_TYPE, null).iterateNext();
+		doc, null, XPathResult.ANY_TYPE, null).iterateNext();
 	if (refFrag) {
 		// citelet looks kind of like this
 		// Powell v. McCormack, 395 US 486 - Supreme Court 1969
@@ -342,7 +372,8 @@ var ItemFactory = function (doc, citeletString, attachmentLinks, titleString /*,
 	this.doc = doc;
 	// working strings
 	this.citelet = citeletString;
-/** handled outside of item factory
+
+	/** handled outside of item factory
 	this.bibtexLink = bibtexLink;
 	this.bibtexData = undefined;
 */
@@ -364,7 +395,7 @@ ItemFactory.prototype.repairTitle = function () {
 	// All-caps words of four or more characters probably need fixing.
 	if (this.v.title.match(/(?:[^a-z]|^)[A-Z]{4,}(?:[^a-z]|$)/)) {
 		this.v.title = ZU.capitalizeTitle(this.v.title.toLowerCase(), true)
-								.replace(/([^0-9a-z])V([^0-9a-z])/, "$1v$2");	
+								.replace(/([^0-9a-z])V([^0-9a-z])/, "$1v$2");
 	}
 };
 
@@ -402,11 +433,13 @@ ItemFactory.prototype.getDate = function () {
 	if (!this.hyphenSplit) {
 		if (this.citelet.match(/\s+-\s+/)) {
 			this.hyphenSplit = this.citelet.split(/\s+-\s+/);
-		} else {
+		}
+		else {
 			m = this.citelet.match(/^(.*),\s+([^,]+Court,\s+[^,]+)$/);
 			if (m) {
 				this.hyphenSplit = [m[1], m[2]];
-			} else {
+			}
+			else {
 				this.hyphenSplit = [this.citelet];
 			}
 		}
@@ -420,7 +453,8 @@ ItemFactory.prototype.getDate = function () {
 				this.v.date = m[2];
 				if (m[1]) {
 					this.hyphenSplit[i] = m[1];
-				} else {
+				}
+				else {
 					this.hyphenSplit[i] = "";
 				}
 				this.hyphenSplit = this.hyphenSplit.slice(0, i + 1);
@@ -429,16 +463,16 @@ ItemFactory.prototype.getDate = function () {
 		}
 	}
 	// If we can find a more specific date in the case's centered text then use it
-	var nodesSnapshot = this.doc.evaluate('//div[@id="gs_opinion"]/center', this.doc, null, XPathResult.ORDERED_NODE_SNAPSHOT_TYPE, null );
-	for ( var iNode = 0; iNode < nodesSnapshot.snapshotLength; iNode++ ) {
+	var nodesSnapshot = this.doc.evaluate('//div[@id="gs_opinion"]/center', this.doc, null, XPathResult.ORDERED_NODE_SNAPSHOT_TYPE, null);
+	for (var iNode = 0; iNode < nodesSnapshot.snapshotLength; iNode++) {
 		var specificDate = nodesSnapshot.snapshotItem(iNode).textContent.trim();
-		// Remove the first word through the first space 
+		// Remove the first word through the first space
 		//  if it starts with "Deci" or it doesn't start with the first three letters of a month
 		//  and if it doesn't start with Submitted or Argued
 		// (So, words like "Decided", "Dated", and "Released" will be removed)
-		specificDate = specificDate.replace(/^(?:Deci|(?!Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec|Submitted|Argued))[a-z]+[.:]?\s*/i,"")
+		specificDate = specificDate.replace(/^(?:Deci|(?!Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec|Submitted|Argued))[a-z]+[.:]?\s*/i, "")
 		// Remove the trailing period, if it is there
-			.replace(/\.$/,"");
+			.replace(/\.$/, "");
 		// If the remaining text is a valid date...
 		if (!isNaN(Date.parse(specificDate))) {
 			// ...then use it
@@ -496,7 +530,8 @@ ItemFactory.prototype.getVolRepPag = function () {
 				}
 				gotOne = true;
 				this.vv.volRepPag.push(volRepPag);
-			} else {
+			}
+			else {
 				break;
 			}
 		}
@@ -533,10 +568,11 @@ ItemFactory.prototype.getAttachments = function (doctype) {
 		if ("string" === typeof this.attachmentLinks[i]) {
 			attachments.push({
 				title: attachmentTitle,
-				url:this.attachmentLinks[i],
-				type:"text/html"
+				url: this.attachmentLinks[i],
+				type: "text/html"
 			});
-		} else {
+		}
+		else {
 			// DOM fragment and parent doc
 			var block = this.attachmentLinks[i];
 			var doc = block.ownerDocument;
@@ -549,12 +585,12 @@ ItemFactory.prototype.getAttachments = function (doctype) {
 			// head element
 			var head = doc.createElement("head");
 			head.innerHTML = '<title>' + title + '</title>';
-			head.innerHTML += '<style type="text/css">' + css + '</style>'; 
+			head.innerHTML += '<style type="text/css">' + css + '</style>';
 
 			var attachmentdoc = Zotero.Utilities.composeDoc(doc, head, block);
 			attachments.push({
 				title: attachmentTitle,
-				document:attachmentdoc
+				document: attachmentdoc
 			});
 
 			// URL for this item
@@ -621,13 +657,15 @@ ItemFactory.prototype.saveItem = function () {
 				}
 				completed_items[i].complete();
 			}
-		} else {
+		}
+		else {
 			this.item = new Zotero.Item("case");
 			this.saveItemCommonVars();
 			this.pushAttachments("Judgement");
 			this.item.complete();
 		}
-	} else {
+	}
+	else {
 		throw new Error("Failed to find title in \"" + this.citelet + "\"");
 	}
 };
@@ -642,7 +680,7 @@ ItemFactory.prototype.saveItemCommonVars = function () {
 };
 
 /*
-  Test Case Descriptions:  (these have not been included in the test case JSON below as per 
+  Test Case Descriptions:  (these have not been included in the test case JSON below as per
 							aurimasv's comment on https://github.com/zotero/translators/pull/833)
 
 		"description": "Legacy test case",

--- a/GFSOSO.js
+++ b/GFSOSO.js
@@ -13,32 +13,7 @@
 }
 
 // attr()/text() v2
-
-
-/*
-	***** BEGIN LICENSE BLOCK *****
-
-	Copyright © 2020-2026 西班牙馅饼, Simon Kornblith, Frank Bennett, Aurimas Vinckevicius
-
-	This file is part of Zotero.
-
-	Zotero is free software: you can redistribute it and/or modify
-	it under the terms of the GNU Affero General Public License as published by
-	the Free Software Foundation, either version 3 of the License, or
-	(at your option) any later version.
-
-	Zotero is distributed in the hope that it will be useful,
-	but WITHOUT ANY WARRANTY; without even the implied warranty of
-	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-	GNU Affero General Public License for more details.
-
-	You should have received a copy of the GNU Affero General Public License
-	along with Zotero. If not, see <http://www.gnu.org/licenses/>.
-
-	***** END LICENSE BLOCK *****
-*/
-
-// `attr` and `text` are built-in global functions provided by Zotero, so we don't redefine them here
+function attr(docOrElem,selector,attr,index){var elem=index?docOrElem.querySelectorAll(selector).item(index):docOrElem.querySelector(selector);return elem?elem.getAttribute(attr):null;}function text(docOrElem,selector,index){var elem=index?docOrElem.querySelectorAll(selector).item(index):docOrElem.querySelector(selector);return elem?elem.textContent:null;}
 
 
 function detectWeb(doc, url) {
@@ -46,12 +21,11 @@ function detectWeb(doc, url) {
 	 * e.g. url of "how cited" page:
 	 *   http://scholar.google.co.jp/scholar_case?about=1101424605047973909&q=kelo&hl=en&as_sdt=2002
 	 */
-	if (url.contains('/scholar_case?')
-		&& !(url.contains('about='))
+	if (url.indexOf('/scholar_case?') != -1
+		&& url.indexOf('about=') == -1
 	) {
 		return "case";
-	}
-	else if (url.contains('/citations?')) {
+	} else if (url.indexOf('/citations?') != -1) {
 		if (getProfileResults(doc, true)) {
 			return "multiple";
 		}
@@ -59,16 +33,14 @@ function detectWeb(doc, url) {
 		//individual saved citation
 		var link = ZU.xpathText(doc, '//a[@class="gsc_vcd_title_link"]/@href');
 		if (!link) return;
-		if (link.contains('/scholar_case?')) {
+		if (link.indexOf('/scholar_case?') != -1) {
 			return 'case';
-		}
-		else {
+		} else {
 			//Can't distinguish book from journalArticle
 			//Both have "Journal" fields
 			return 'journalArticle';
 		}
-	}
-	else if (getSearchResults(doc, true)) {
+	} else if (getSearchResults(doc, true)) {
 		return "multiple";
 	}
 }
@@ -78,10 +50,10 @@ function getSearchResults(doc, checkOnly, itemInfo) {
 	var items = {};
 	var found = false;
 	var rows = doc.querySelectorAll('.gs_r[data-cid]');
-	for (var i = 0; i < rows.length; i++) {
+	for (var i=0; i<rows.length; i++) {
 		var href = rows[i].dataset.cid;
 		var title = text(rows[i], '.gs_rt');
-		var url = rows[i].querySelector('a[id]').href;
+		var url = rows[i].querySelector('a[id]').href
 		if (!href || !title) continue;
 		if (checkOnly) return true;
 		found = true;
@@ -96,7 +68,7 @@ function getProfileResults(doc, checkOnly, itemInfo) {
 	var items = {};
 	var found = false;
 	var rows = doc.querySelectorAll('a.gsc_a_at');
-	for (var i = 0; i < rows.length; i++) {
+	for (var i=0; i<rows.length; i++) {
 		var href = rows[i].dataset.href;
 		var title = rows[i].textContent;
 		if (!href || !title) continue;
@@ -125,13 +97,12 @@ function doWeb(doc, url) {
 				//here it is enough to know the ids and we can call scrape directly
 				scrape(doc, ids, itemInfo);
 			});
-		}
-		else if (getProfileResults(doc, true)) {
+		} else if (getProfileResults(doc, true)) {
 			Zotero.selectItems(getProfileResults(doc, false, itemInfo), function (items) {
 				if (!items) {
 					return true;
 				}
-				var articles = {};
+				var articles  = {}
 				for (var i in items) {
 					articles.push(i);
 				}
@@ -139,8 +110,7 @@ function doWeb(doc, url) {
 				ZU.processDocuments(articles, scrape);
 			});
 		}
-	}
-	else {
+	} else {
 		//e.g. https://scholar.google.de/citations?view_op=view_citation&hl=de&user=INQwsQkAAAAJ&citation_for_view=INQwsQkAAAAJ:u5HHmVD_uO8C
 		scrape(doc, url, type);
 	}
@@ -150,41 +120,41 @@ function doWeb(doc, url) {
 function scrape(doc, idsOrUrl, type) {
 	if (Array.isArray(idsOrUrl)) {
 		scrapeIds(doc, idsOrUrl, type);
-	}
-	else if (type && type == "case") {
-		scrapeCase(doc, idsOrUrl);
-	}
-	else {
-		var related = ZU.xpathText(doc, '//a[contains(@href, "q=related:")]/@href');
-		if (!related) {
-			throw new Error("Could not locate related URL");
+	} else {
+		if (type && type=="case") {
+			scrapeCase(doc, idsOrUrl);
+		} else {
+			var related = ZU.xpathText(doc, '//a[contains(@href, "q=related:")]/@href');
+			if (!related) {
+				throw new Error("Could not locate related URL");
+			}
+			var itemID = related.match(/=related:([^:]+):/);
+			if (itemID) {
+				scrapeIds(doc, [itemID[1]]);
+			} else {
+				Z.debug("Can't find itemID. related URL is " + related);
+				throw new Error("Cannot extract itemID from related link");
+			}
 		}
-		var itemID = related.match(/=related:([^:]+):/);
-		if (itemID) {
-			scrapeIds(doc, [itemID[1]]);
-		}
-		else {
-			Z.debug("Can't find itemID. related URL is " + related);
-			throw new Error("Cannot extract itemID from related link");
-		}
 	}
+	
 }
 
 
 function scrapeIds(doc, ids, itemInfo) {
-	for (let i = 0; i < ids.length; i++) {
+	for (let i=0; i<ids.length; i++) {
 		// We need here 'let' to access id later in the nested functions
 		let context = doc.querySelector('.gs_r[data-cid="' + ids[i] + '"]');
-		if (!context && ids.length == 1) context = doc;
+		if (!context && ids.length==1) context = doc;
 		var citeUrl = '/scholar?q=info:' + ids[i] + ':scholar.google.com/&output=cite&scirp=1';
 		// For 'My Library' we check the search field at the top
 		// and then in these cases change the citeUrl accordingly.
-		var scilib = attr(doc, '#gs_hdr_frm input[name="scilib"]', 'value');
-		if (scilib && scilib == 1) {
+		var scilib = attr(doc, '#gs_hdr_frm input[name="scilib"]', 'value')
+		if (scilib && scilib==1) {
 			var citeUrl = '/scholar?scila=' + ids[i] + '&output=cite&scirp=1';
 		}
 		var idx = i;
-		ZU.doGet(citeUrl, function (citePage) {
+		ZU.doGet(citeUrl, function(citePage) {
 			var m = citePage.match(/href="((https?:\/\/[a-z\.]*)?\/scholar.bib\?[^"]+)/);
 			if (!m) {
 				//Saved lists and possibly other places have different formats for BibTeX URLs
@@ -195,25 +165,25 @@ function scrapeIds(doc, ids, itemInfo) {
 				var msg = "Could not find BibTeX URL";
 				var title = citePage.match(/<title>(.*?)<\/title>/i);
 				if (title) {
-					if (title) msg += ' Got page with title "' + title[1] + '"';
+					if (title) msg += ' Got page with title "' + title[1] +'"';
 				}
 				throw new Error(msg);
 			}
 			var bibUrl = ZU.unescapeHTML(m[1]);
-			var idx = i;
-			ZU.doGet(bibUrl, function (bibtex) {
+			var idx = i
+			ZU.doGet(bibUrl, function(bibtex) {
 				var translator = Zotero.loadTranslator("import");
 				translator.setTranslator("9cb70025-a888-4a29-a210-93ec52da40d4");
 				translator.setString(bibtex);
-				translator.setHandler("itemDone", function (obj, item) {
+				translator.setHandler("itemDone", function(obj, item) {
 					//these two variables are extracted from the context
 					var titleLink = attr(context, 'h3 a, #gsc_vcd_title a', 'href');
 					var secondLine = text(context, '.gs_a') || '';
 					//case are not recognized and can be characterized by the
 					//titleLink, or that the second line starts with a number
 					//e.g. 1 Cr. 137 - Supreme Court, 1803
-					if ((titleLink && titleLink.contains('/scholar_case?'))
-						|| secondLine && ['0', '1', '2', '3', '4', '5', '6', '7', '8', '9'].contains(secondLine[0])) {
+					if ((titleLink && titleLink.indexOf('/scholar_case?')>-1) || 
+						secondLine && ['0', '1', '2', '3', '4', '5', '6', '7', '8', '9'].indexOf(secondLine[0])>-1) {
 						item.itemType = "case";
 						item.caseName = item.title;
 						item.reporter = item.publicationTitle;
@@ -223,10 +193,10 @@ function scrapeIds(doc, ids, itemInfo) {
 					}
 					//patents are not recognized but are easily detected
 					//by the titleLink or second line
-					if ((titleLink && titleLink.contains('google.com/patents/')) || secondLine.contains('Google Patents')) {
+					if ((titleLink && titleLink.indexOf('google.com/patents/')>-1) || secondLine.indexOf('Google Patents')>-1) {
 						item.itemType = "patent";
 						//authors are inventors
-						for (var i = 0, n = item.creators.length; i < n; i++) {
+						for (var i=0, n=item.creators.length; i<n; i++) {
 							item.creators[i].creatorType = 'inventor';
 						}
 						//country and patent number
@@ -246,20 +216,20 @@ function scrapeIds(doc, ids, itemInfo) {
 					
 					//delete "others" as author
 					if (item.creators.length) {
-						var lastCreatorIndex = item.creators.length - 1,
+						var lastCreatorIndex = item.creators.length-1,
 							lastCreator = item.creators[lastCreatorIndex];
-						if (lastCreator.lastName === "others" && (lastCreator.fieldMode === 1 || lastCreator.firstName === "")) {
+						if (lastCreator.lastName === "others" && (lastCreator.fieldMode === 1 ||lastCreator.firstName === "")) {
 							item.creators.splice(lastCreatorIndex, 1);
 						}
 					}
 					
 					//clean author names
-					for (var j = 0, m = item.creators.length; j < m; j++) {
+					for (var j=0, m=item.creators.length; j<m; j++) {
 						if (!item.creators[j].firstName) continue;
 			
 						item.creators[j] = ZU.cleanAuthor(
-							item.creators[j].lastName + ', '
-								+ item.creators[j].firstName,
+							item.creators[j].lastName + ', ' +
+								item.creators[j].firstName,
 							item.creators[j].creatorType,
 							true);
 					}
@@ -276,11 +246,11 @@ function scrapeIds(doc, ids, itemInfo) {
 						var m = documentLinkTitle.match(/^\[(\w+)\]/);
 						if (m) {
 							var mimeTypes = {
-								PDF: 'application/pdf',
-								DOC: 'application/msword',
-								HTML: 'text/html'
+								'PDF': 'application/pdf',
+								'DOC': 'application/msword',
+								'HTML': 'text/html'
 							};
-							if (Object.keys(mimeTypes).contains(m[1].toUpperCase())) {
+							if (Object.keys(mimeTypes).indexOf(m[1].toUpperCase())>-1) {
 								attachment.mimeType = mimeTypes[m[1]];
 							}
 						}
@@ -322,7 +292,7 @@ var scrapeCase = function (doc, url) {
 	// Citelet is identified by
 	// id="gsl_reference"
 	var refFrag = doc.evaluate('//div[@id="gsl_reference"] | //div[@id="gs_reference"]',
-		doc, null, XPathResult.ANY_TYPE, null).iterateNext();
+					doc, null, XPathResult.ANY_TYPE, null).iterateNext();
 	if (refFrag) {
 		// citelet looks kind of like this
 		// Powell v. McCormack, 395 US 486 - Supreme Court 1969
@@ -372,8 +342,7 @@ var ItemFactory = function (doc, citeletString, attachmentLinks, titleString /*,
 	this.doc = doc;
 	// working strings
 	this.citelet = citeletString;
-
-	/** handled outside of item factory
+/** handled outside of item factory
 	this.bibtexLink = bibtexLink;
 	this.bibtexData = undefined;
 */
@@ -395,7 +364,7 @@ ItemFactory.prototype.repairTitle = function () {
 	// All-caps words of four or more characters probably need fixing.
 	if (this.v.title.match(/(?:[^a-z]|^)[A-Z]{4,}(?:[^a-z]|$)/)) {
 		this.v.title = ZU.capitalizeTitle(this.v.title.toLowerCase(), true)
-								.replace(/([^0-9a-z])V([^0-9a-z])/, "$1v$2");
+								.replace(/([^0-9a-z])V([^0-9a-z])/, "$1v$2");	
 	}
 };
 
@@ -433,13 +402,11 @@ ItemFactory.prototype.getDate = function () {
 	if (!this.hyphenSplit) {
 		if (this.citelet.match(/\s+-\s+/)) {
 			this.hyphenSplit = this.citelet.split(/\s+-\s+/);
-		}
-		else {
+		} else {
 			m = this.citelet.match(/^(.*),\s+([^,]+Court,\s+[^,]+)$/);
 			if (m) {
 				this.hyphenSplit = [m[1], m[2]];
-			}
-			else {
+			} else {
 				this.hyphenSplit = [this.citelet];
 			}
 		}
@@ -453,8 +420,7 @@ ItemFactory.prototype.getDate = function () {
 				this.v.date = m[2];
 				if (m[1]) {
 					this.hyphenSplit[i] = m[1];
-				}
-				else {
+				} else {
 					this.hyphenSplit[i] = "";
 				}
 				this.hyphenSplit = this.hyphenSplit.slice(0, i + 1);
@@ -463,16 +429,16 @@ ItemFactory.prototype.getDate = function () {
 		}
 	}
 	// If we can find a more specific date in the case's centered text then use it
-	var nodesSnapshot = this.doc.evaluate('//div[@id="gs_opinion"]/center', this.doc, null, XPathResult.ORDERED_NODE_SNAPSHOT_TYPE, null);
-	for (var iNode = 0; iNode < nodesSnapshot.snapshotLength; iNode++) {
+	var nodesSnapshot = this.doc.evaluate('//div[@id="gs_opinion"]/center', this.doc, null, XPathResult.ORDERED_NODE_SNAPSHOT_TYPE, null );
+	for ( var iNode = 0; iNode < nodesSnapshot.snapshotLength; iNode++ ) {
 		var specificDate = nodesSnapshot.snapshotItem(iNode).textContent.trim();
-		// Remove the first word through the first space
+		// Remove the first word through the first space 
 		//  if it starts with "Deci" or it doesn't start with the first three letters of a month
 		//  and if it doesn't start with Submitted or Argued
 		// (So, words like "Decided", "Dated", and "Released" will be removed)
-		specificDate = specificDate.replace(/^(?:Deci|(?!Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec|Submitted|Argued))[a-z]+[.:]?\s*/i, "")
+		specificDate = specificDate.replace(/^(?:Deci|(?!Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec|Submitted|Argued))[a-z]+[.:]?\s*/i,"")
 		// Remove the trailing period, if it is there
-			.replace(/\.$/, "");
+			.replace(/\.$/,"");
 		// If the remaining text is a valid date...
 		if (!isNaN(Date.parse(specificDate))) {
 			// ...then use it
@@ -530,8 +496,7 @@ ItemFactory.prototype.getVolRepPag = function () {
 				}
 				gotOne = true;
 				this.vv.volRepPag.push(volRepPag);
-			}
-			else {
+			} else {
 				break;
 			}
 		}
@@ -568,11 +533,10 @@ ItemFactory.prototype.getAttachments = function (doctype) {
 		if ("string" === typeof this.attachmentLinks[i]) {
 			attachments.push({
 				title: attachmentTitle,
-				url: this.attachmentLinks[i],
-				type: "text/html"
+				url:this.attachmentLinks[i],
+				type:"text/html"
 			});
-		}
-		else {
+		} else {
 			// DOM fragment and parent doc
 			var block = this.attachmentLinks[i];
 			var doc = block.ownerDocument;
@@ -585,12 +549,12 @@ ItemFactory.prototype.getAttachments = function (doctype) {
 			// head element
 			var head = doc.createElement("head");
 			head.innerHTML = '<title>' + title + '</title>';
-			head.innerHTML += '<style type="text/css">' + css + '</style>';
+			head.innerHTML += '<style type="text/css">' + css + '</style>'; 
 
 			var attachmentdoc = Zotero.Utilities.composeDoc(doc, head, block);
 			attachments.push({
 				title: attachmentTitle,
-				document: attachmentdoc
+				document:attachmentdoc
 			});
 
 			// URL for this item
@@ -657,15 +621,13 @@ ItemFactory.prototype.saveItem = function () {
 				}
 				completed_items[i].complete();
 			}
-		}
-		else {
+		} else {
 			this.item = new Zotero.Item("case");
 			this.saveItemCommonVars();
 			this.pushAttachments("Judgement");
 			this.item.complete();
 		}
-	}
-	else {
+	} else {
 		throw new Error("Failed to find title in \"" + this.citelet + "\"");
 	}
 };
@@ -680,7 +642,7 @@ ItemFactory.prototype.saveItemCommonVars = function () {
 };
 
 /*
-  Test Case Descriptions:  (these have not been included in the test case JSON below as per
+  Test Case Descriptions:  (these have not been included in the test case JSON below as per 
 							aurimasv's comment on https://github.com/zotero/translators/pull/833)
 
 		"description": "Legacy test case",

--- a/ProQuestCN Thesis.js
+++ b/ProQuestCN Thesis.js
@@ -36,10 +36,9 @@
 */
 function detectWeb(doc, url) {
 	if (url.includes('/thesisDetails/')) {
-		
 		return 'thesis';
 	}
-	else if (getSearchResults(doc,true)) {
+	else if (getSearchResults(doc, true)) {
 		return 'multiple';
 	}
 	return false;
@@ -50,34 +49,32 @@ function getSearchResults(doc, checkOnly) {
 	var found = false;
 	var rows = ZU.xpath(doc, "//div[@id='basic_search']/table[@class='table']");
 	if (checkOnly) {
-		
 		return rows.length ? 'multiple' : false;
 	}
-	for (let i=0; i < rows.length; i++) {
+	for (let i = 0; i < rows.length; i++) {
 		//Z.debug(rows[0]);
 		let title = ZU.xpath(rows[i], ".//td[@colspan='3']/a")[0];
 		//Z.debug(title.innerText);
 		//let click = title.;
 		//Z.debug(click);
 		let href = title.getAttribute('href');
-		href = "http://www.pqdtcn.com/"+href;
+		href = "http://www.pqdtcn.com/" + href;
 		//Z.debug(href);
 		title = ZU.trimInternal(title.textContent);
 		if (!href || !title) continue;
 		found = true;
-		items[href] = (i+1) + " " + title;
+		items[href] = (i + 1) + " " + title;
 		//Z.debug(items[href]);
 	}
 	return found ? items : false;
 }
 
 function doWeb(doc, url) {
-	
 	if (detectWeb(doc, url) == "multiple") {
 		Zotero.selectItems(getSearchResults(doc, false), function (items) {
 			if (items) {
-					processURL(Object.keys(items));
-				}
+				processURL(Object.keys(items));
+			}
 		});
 	}
 	else {
@@ -89,7 +86,7 @@ function processURL(urls) {
 	var url = urls.pop();
 	//Z.debug(url);
 	//ZU.doGet(url, function(text) {
-	ZU.processDocuments(url,function(doc){
+	ZU.processDocuments(url, function (doc) {
 		//Z.debug(text);
 		//var parser = new DOMParser();
 		//var doc = parser.parseFromString(text, "text/html");
@@ -98,16 +95,16 @@ function processURL(urls) {
 		if (urls.length) {
 			processURL(urls);
 		}
-	})
+	});
 }
-function scrape(doc,url){
-	var newItem=new Zotero.Item('thesis');
+function scrape(doc, url) {
+	var newItem = new Zotero.Item('thesis');
 	
-	var note=ZU.xpath(doc,"//div[@id='summary']/div/span");
-	if(note.length){
-		newItem.abstractNote=ZU.trimInternal(note[0].innerText);
+	var note = ZU.xpath(doc, "//div[@id='summary']/div/span");
+	if (note.length) {
+		newItem.abstractNote = ZU.trimInternal(note[0].innerText);
 	}
-	var index=ZU.xpath(doc,"//div[@style='margin-top: 9px;']");
+	var index = ZU.xpath(doc, "//div[@style='margin-top: 9px;']");
 	
 	//将所有的信息合并在一起后根据关键词找到对应的信息
 	//但是如果某一个关键词是空的话，整个列表的结构会乱
@@ -186,110 +183,108 @@ function scrape(doc,url){
 	//分析发现，论文的关键词信息是固定的，可以直接通过索引号来实现对应信息的提取
 	//Z.debug(index);
 	//Z.debug(index[0].children);
-	if(index.length){
-		var title=index[0].children[1].innerText.split(":")[1];
-		if(title.length){
-			newItem.title=ZU.trimInternal(title);
+	if (index.length) {
+		var title = index[0].children[1].innerText.split(":")[1];
+		if (title.length) {
+			newItem.title = ZU.trimInternal(title);
 		}
 		
-		var authors=index[0].children[2].innerText.split(":")[1];
+		var authors = index[0].children[2].innerText.split(":")[1];
 		//Z.debug(authors);
-		if(authors.length){
+		if (authors.length) {
 			//Z.debug(authors);
-			authors=new Array(ZU.trimInternal(authors));
-			authors = handleName(authors,false);
+			authors = new Array(ZU.trimInternal(authors));
+			authors = handleName(authors, false);
 			//Z.debug(authors);
 		}
-		var supervisor=index[0].children[11].innerText.split(":")[1];
-		if(supervisor.length){
-			
+		var supervisor = index[0].children[11].innerText.split(":")[1];
+		if (supervisor.length) {
 			//导师可能有多个,具体以什么符号分割还未核实
-			supervisor=ZU.trimInternal(supervisor).split(";");
+			supervisor = ZU.trimInternal(supervisor).split(";");
 			//Z.debug(supervisor);
-			supervisor=handleName(supervisor,true);
+			supervisor = handleName(supervisor, true);
 			//Z.debug(supervisor);
 		}
-		if(supervisor.length || authors.length){
-			newItem.creators=authors.concat(supervisor);
+		if (supervisor.length || authors.length) {
+			newItem.creators = authors.concat(supervisor);
 		}
 		
-		var pages=index[0].children[3].innerText.split(":")[1];
-		if(pages.length){
-			newItem.numPages=ZU.trimInternal(pages);
+		var pages = index[0].children[3].innerText.split(":")[1];
+		if (pages.length) {
+			newItem.numPages = ZU.trimInternal(pages);
 		}
 		
-		var date=index[0].children[4].innerText.split(":")[1];
-		if(date.length){
-			newItem.date=ZU.trimInternal(date);
+		var date = index[0].children[4].innerText.split(":")[1];
+		if (date.length) {
+			newItem.date = ZU.trimInternal(date);
 		}
 		
-		var university=index[0].children[6].innerText.split(":")[1];
-		if(university.length){
-			newItem.university=ZU.trimInternal(university);
+		var university = index[0].children[6].innerText.split(":")[1];
+		if (university.length) {
+			newItem.university = ZU.trimInternal(university);
 		}
 		
-		var place=index[0].children[9].innerText.split(":")[1];
-		if(place.length){
-			newItem.place=ZU.trimInternal(place);
+		var place = index[0].children[9].innerText.split(":")[1];
+		if (place.length) {
+			newItem.place = ZU.trimInternal(place);
 		}
 		
-		var ISBN=index[0].children[10].innerText.split(":")[1];
-		if(ISBN.length){
-			newItem.ISBN=ZU.trimInternal(ISBN);
+		var ISBN = index[0].children[10].innerText.split(":")[1];
+		if (ISBN.length) {
+			newItem.ISBN = ZU.trimInternal(ISBN);
 		}
 		
-		var type=index[0].children[13].innerText.split(":")[1];
-		if(type.length){
-			newItem.thesisType=ZU.trimInternal(type);
+		var type = index[0].children[13].innerText.split(":")[1];
+		if (type.length) {
+			newItem.thesisType = ZU.trimInternal(type);
 		}
 		
-		var language=index[0].children[14].innerText.split(":")[1];
-		if(language.length){
-			newItem.language=ZU.trimInternal(language);
+		var language = index[0].children[14].innerText.split(":")[1];
+		if (language.length) {
+			newItem.language = ZU.trimInternal(language);
 		}
 		
 		
 		var webType = detectWeb(doc, url);
 		if (webType && webType != 'multiple') {
-			var domain="http://www.pqdtcn.com/";
+			var domain = "http://www.pqdtcn.com/";
 			//var domain="http://2253809.rm.cglhub.com/"
-			ZU.doGet(domain+"thesis/downloadControl",function(text){
-				Z.debug(domain+"thesis/downloadControl");	
+			ZU.doGet(domain + "thesis/downloadControl", function (text) {
+				Z.debug(domain + "thesis/downloadControl");
 				Z.debug(text);
 				//succ=text.split(",")[0].split(":")[1];
 		
 				//Z.debug(succ);
-				if(!text.length){
+				if (!text.length) {
 					newItem.url = url;
 					newItem.complete();
 					return;
 				}
-				var data=JSON.parse(text);
+				var data = JSON.parse(text);
 				
 				//accesToken=text.split(",")[1].split(":")[1];
 				//accesToken=accesToken.slice(1,accesToken.length-2);
-				accesToken=data.accessToken;
+				var accesToken = data.accessToken;
 				
-				var code=(ZU.xpath(doc,"//input[@id='thesisEncryptCode']"))[0].getAttribute("value");
-				var sites = ZU.xpath(doc,"//li[@role='presentation']");
+				var code = (ZU.xpath(doc, "//input[@id='thesisEncryptCode']"))[0].getAttribute("value");
+				var sites = ZU.xpath(doc, "//li[@role='presentation']");
 				//获取可供下载pdf的服务器编号
-				var remoteSites=[];
-				if(sites.length){
-				for (let site of sites){
+				var remoteSites = [];
+				if (sites.length) {
+					for (let site of sites) {
 					//Z.debug(site.innerText);
-					remoteSites.push(site.getElementsByTagName("a")[0].getAttribute("value"));
+						remoteSites.push(site.getElementsByTagName("a")[0].getAttribute("value"));
 					}
 				}
-				if(!remoteSites.length){
+				if (!remoteSites.length) {
 					newItem.url = url;
 					newItem.complete();
 					return;
 				}
 				Z.debug(remoteSites);
-				var pdfurl=domain+"thesis/download/"+remoteSites[Math.floor(Math.random()*remoteSites.length)]+"/"+code+"?accessToken="+accesToken;
+				var pdfurl = domain + "thesis/download/" + remoteSites[Math.floor(Math.random() * remoteSites.length)] + "/" + code + "?accessToken=" + accesToken;
 				//Z.debug(pdfurl);
 		
-				var attachments = [];
 				Z.debug(pdfurl);
 				if (pdfurl) {
 					newItem.attachments.push({
@@ -300,26 +295,24 @@ function scrape(doc,url){
 				}
 				newItem.url = url;
 				newItem.complete();
-			})
+			});
 		}
 	}
-	
 }
-function getNextItem(index,item){
-	return index[index.indexOf(item)+1];
-}
-function handleName(authors,isContri){
-	var creators=[];
+// function getNextItem(index, item) {
+// 	return index[index.indexOf(item) + 1];
+// }
+function handleName(authors, isContri) {
+	var creators = [];
 	for (let author of authors) {
-		
 		var creator = {};
 		var lastSpace = author.lastIndexOf(',');
-		if (author.search(/[A-Za-z]/) !== -1 && lastSpace !== -1) {
+		if (/[A-Za-z]/.test(author) && lastSpace !== -1) {
 			// English
 			creator.lastName = author.slice(0, lastSpace);
-			creator.firstName = author.slice(lastSpace+1);
+			creator.firstName = author.slice(lastSpace + 1);
 		}
-		if(isContri){
+		if (isContri) {
 			creator.creatorType = "contributor";
 		}
 	}

--- a/Wanfang Med.js
+++ b/Wanfang Med.js
@@ -218,8 +218,8 @@ function getLabeledData(rows, labelGetter, dataGetter, defaultElm) {
 			for (const label of labels) {
 				const result = data(label, element);
 				if (
-					(element && /\S/.test(result.textContent)) ||
-					(!element && /\S/.test(result))) {
+					(element && /\S/.test(result.textContent))
+					|| (!element && /\S/.test(result))) {
 					return result;
 				}
 			}

--- a/Web of Science Tagged.js
+++ b/Web of Science Tagged.js
@@ -304,9 +304,9 @@ function saveRecord(record) {
 				}
 			}
 		}
-    else if (field == 'DOI') {
-      value = ZU.cleanDOI(value);
-    }
+		else if (field == 'DOI') {
+			value = ZU.cleanDOI(value);
+		}
 		else if (field == 'filingDate') {
 			value = ZU.strToISO(value);
 		}

--- a/Zhihu.js
+++ b/Zhihu.js
@@ -47,7 +47,7 @@ function detectWeb(doc, url) {
 	else if (url.includes('/p/')) {
 		return 'blogPost';
 	}
-	else if (url.includes('/collection/') || url.includes('/column/') || url.includes('/posts') || url.includes('/answers')){
+	else if (url.includes('/collection/') || url.includes('/column/') || url.includes('/posts') || url.includes('/answers')) {
 		return 'multiple';
 	}
 	else if (url.includes('/search?') && !url.includes('type=content')) {
@@ -123,11 +123,13 @@ async function scrape(doc, url = doc.location.href) {
 						const decodedTarget = decodeURIComponent(target);
 						// 返回解码后的 URL 和原来的分隔符
 						return decodedTarget + quoteOrDelimiter;
-					} else {
+					}
+					else {
 						// 如果没有 target 参数，返回原始匹配
 						return match;
 					}
-				} catch (e) {
+				}
+				catch (e) {
 					// 如果 href 不是有效的 URL，返回原始匹配
 					return match;
 				}
@@ -139,7 +141,7 @@ async function scrape(doc, url = doc.location.href) {
 			newItem.notes.push({ note: noteContent });
 			break;
 		}
-		case 'blogPost':
+		case 'blogPost': {
 			newItem.title = attr(doc, 'meta[property="og:title"]', 'content');
 			let noteContent = doc.querySelector('div.RichText').innerHTML;
 			// 图片
@@ -161,11 +163,13 @@ async function scrape(doc, url = doc.location.href) {
 						const decodedTarget = decodeURIComponent(target);
 						// 返回解码后的 URL 和原来的分隔符
 						return decodedTarget + quoteOrDelimiter;
-					} else {
+					}
+					else {
 						// 如果没有 target 参数，返回原始匹配
 						return match;
 					}
-				} catch (e) {
+				}
+				catch (e) {
 					// 如果 href 不是有效的 URL，返回原始匹配
 					return match;
 				}
@@ -178,6 +182,7 @@ async function scrape(doc, url = doc.location.href) {
 			// optimal DOM for zhuanlan post
 			optimalDOM(doc);
 			break;
+		}
 	}
 	newItem.url = url;
 	newItem.language = 'zh-CN';

--- a/Zhizhen.js
+++ b/Zhizhen.js
@@ -90,8 +90,8 @@ async function doWeb(doc, url) {
 async function scrape(doc, url = doc.location.href) {
 	const data = getLabeledData(
 		doc.querySelectorAll('.savelist_con > .card_line'),
-		(row) => innerText(row, 'dt > span'),
-		(row) => row.querySelector('dd'),
+		row => innerText(row, 'dt > span'),
+		row => row.querySelector('dd'),
 		doc.createElement('div')
 	);
 	const extra = new Extra();
@@ -255,8 +255,8 @@ function getLabeledData(rows, labelGetter, dataGetter, defaultElm) {
 			for (const label of labels) {
 				const result = data(label, element);
 				if (
-					(element && /\S/.test(result.textContent)) ||
-					(!element && /\S/.test(result))) {
+					(element && /\S/.test(result.textContent))
+					|| (!element && /\S/.test(result))) {
 					return result;
 				}
 			}


### PR DESCRIPTION
## 描述

对全仓库运行 `eslint --fix`，自动修复 **400+ 个代码风格和质量问题**，涉及 **11 个文件**。

### 主要变更

| 文件 | 修复内容 |
|------|---------|
| `CCPINFO.js` | CRLF → LF 换行符修复、缩进修复 |
| `CNKI.js` | 格式化修复 |
| `CNKI e-Books.js` | 格式化修复 |
| `CQVIP Qikan.js` | 注释掉未使用的 `getPDF` 函数（保留供参考） |
| `E-Tiller.js` | 修复变量名 `enCcreator` → `enCreator` |
| `GFSOSO.js` | 移除重复定义的 `attr`/`text` 函数（Zotero 已内置） |
| `ProQuestCN Thesis.js` | 添加缺失的 `var` 声明、移除未使用的 `attachments`/`getNextItem` |
| `Wanfang Med.js` | `operator-linebreak` 修复 |
| `Web of Science Tagged.js` | 空格缩进 → 制表符缩进 |
| `Zhihu.js` | `no-case-declarations` 修复（为 `case 'blogPost'` 添加块级作用域） |
| `Zhizhen.js` | `operator-linebreak` 修复 |
| `data/updateJSON.js` | 添加 `/* eslint-env node */` 环境声明 |

### 剩余问题

本次未修复 ~39 个遗留问题，主要集中在 `GFSOSO.js`（Google Scholar 旧版转换器），包含深层的结构性问题（`no-redeclare`、`no-undef`、`consistent-return` 等），建议单独处理。