### PR TITLE
fix(jsconfig): resolve TypeScript type definition file not found error

### DIFF
--- a/jsconfig.json
+++ b/jsconfig.json
@@ -4,7 +4,7 @@
     "allowSyntheticDefaultImports": true,
     "noEmit": true,
     "checkJs": true,
-    "lib": ["dom", "es2017"],
-    "types": ["index.d.ts"]
-  }
+    "lib": ["dom", "es2017"]
+  },
+  "include": ["**/*.js", "index.d.ts"]
 }


### PR DESCRIPTION
修复 `jsconfig.json` 中的 TypeScript 配置错误。

## 问题

`compilerOptions.types` 字段用于指定类型包（如 `@types/node`），不应用于本地 `.d.ts` 文件。使用 `"types": ["index.d.ts"]` 导致 TypeScript 报告：

> 找不到"index.d.ts"的类型定义文件。

## 修复

将 `index.d.ts` 引用从 `compilerOptions.types` 移到顶层 `include` 数组，这是引入本地声明文件的正确方式。