### PR TITLE
refactor: add shared utility functions to CNKI.js exports to reduce duplication

### DIFF
--- a/CNKI CHKD.js
+++ b/CNKI CHKD.js
@@ -219,6 +219,8 @@ const typeMap = {
 	zh: zhTypeMap
 };
 
+// NOTE: This function is duplicated in CNKI.js (the canonical source).
+// If modifying, please update CNKI.js's exports.getLabeledData as well.
 function getLabeledData(rows, labelGetter, dataGetter, defaultElm) {
 	const labeledElm = {};
 	for (const row of rows) {

--- a/CNKI Oversea.js
+++ b/CNKI Oversea.js
@@ -565,6 +565,8 @@ const typeMap = {
 	zh: zhTypeMap
 };
 
+// NOTE: This function is duplicated in CNKI.js (the canonical source).
+// If modifying, please update CNKI.js's exports.getLabeledData as well.
 function getLabeledData(rows, labelGetter, dataGetter, defaultElm) {
 	const labeledElm = {};
 	for (const row of rows) {

--- a/CNKI.js
+++ b/CNKI.js
@@ -801,7 +801,15 @@ var exports = {
 	data: undefined,
 	typeMap,
 	scrapeMain,
-	getItemFromAPI
+	getItemFromAPI,
+	// Shared utility functions — used by CNKI Oversea, CNKI CHKD, and other CNKI sub-translators
+	getLabeledData,
+	removeNode,
+	extractTitle,
+	setExtra,
+	cleanAuthor,
+	detectLanguage,
+	addAttachments
 };
 
 /** BEGIN TEST CASES **/


### PR DESCRIPTION
## 背景

在代码审查中发现，`CNKI.js`、`CNKI Oversea.js`、`CNKI CHKD.js` 三个文件各自定义了完全相同的工具函数（`getLabeledData`、`removeNode`、`extractTitle`、`setExtra`、`cleanAuthor` 等），违反了 DRY 原则。

## 变更

1. **CNKI.js**: 将共用工具函数添加到 `exports` 对象中，使其可通过 `Z.loadTranslator('web')` 被其他转换器程序化引用
2. **CNKI Oversea.js**: 在 `getLabeledData` 前添加注释，指向 CNKI.js 作为规范来源
3. **CNKI CHKD.js**: 同上

## 后续

当前保留子转换器中的重复函数以维持独立兼容性。未来可以：
- 在子转换器中通过 `Z.loadTranslator('web')` 动态引用 CNKI.js 的导出函数
- 或在 Zotero 框架支持更好的代码共享机制后统一迁移