### PR TITLE
增加三个翻译器

### DIFF
--- a/Aozora Bunko.js
+++ b/Aozora Bunko.js
@@ -1,0 +1,246 @@
+{
+	"translatorID": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+	"label": "Aozora Bunko",
+	"creator": "Zotero User",
+	"target": "^https?://www\\.aozora\\.gr\\.jp/cards/\\d+/files/\\d+_\\d+\\.html",
+	"minVersion": "5.0",
+	"maxVersion": "",
+	"priority": 100,
+	"inRepository": true,
+	"translatorType": 4,
+	"browserSupport": "gcsibv",
+	"lastUpdated": "2026-07-12 13:00:00"
+}
+
+/*
+	***** BEGIN LICENSE BLOCK *****
+
+	Copyright © 2026 Zotero User
+
+	This file is part of Zotero.
+
+	Zotero is free software: you can redistribute it and/or modify
+	it under the terms of the GNU Affero General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	Zotero is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+	GNU Affero General Public License for more details.
+
+	You should have received a copy of the GNU Affero General Public License
+	along with Zotero. If not, see <http://www.gnu.org/licenses/>.
+
+	***** END LICENSE BLOCK *****
+*/
+
+function detectWeb(doc, url) {
+	return 'book';
+}
+
+function doWeb(doc, url) {
+	scrape(doc, url);
+}
+
+function scrape(doc, url) {
+	var item = new Zotero.Item('book');
+
+	// Title and author from h1.title and h2.author
+	var titleEl = doc.querySelector('h1.title, .title');
+	var authorEl = doc.querySelector('h2.author, .author');
+
+	item.title = titleEl ? ZU.trimInternal(titleEl.textContent) : doc.title;
+	item.url = url;
+	item.libraryCatalog = '青空文庫';
+	item.language = 'ja';
+
+	var authorName = '';
+	if (authorEl) {
+		authorName = ZU.trimInternal(authorEl.textContent);
+		item.creators.push({
+			lastName: authorName,
+			creatorType: 'author',
+			fieldMode: 1
+		});
+	}
+
+	// Extract bibliographic information
+	var bibInfo = doc.querySelector('.bibliographical_information, .bibliographic_information');
+	var extraParts = [];
+	if (bibInfo) {
+		var bibText = ZU.trimInternal(bibInfo.textContent);
+
+		// 底本 (source text)
+		var sourceMatch = bibText.match(/底本[：:]\s*「(.+?)」\s*(.+?)[\n\r]/);
+		if (sourceMatch) {
+			item.publisher = sourceMatch[2].trim();
+			extraParts.push('底本: 『' + sourceMatch[1] + '』 ' + sourceMatch[2].trim());
+		}
+
+		// 初出 (first publication)
+		var firstPubMatch = bibText.match(/初出[：:]\s*「(.+?)」[\n\r]/);
+		if (firstPubMatch) {
+			extraParts.push('初出: 『' + firstPubMatch[1] + '』');
+		}
+
+		// Date from 初出 or 底本
+		var dateMatch = bibText.match(/(\d{4})[（(平成大正昭和明]/);
+		if (dateMatch) {
+			item.date = dateMatch[1];
+		}
+
+		// 入力 (inputter) and 校正 (proofreader)
+		var inputMatch = bibText.match(/入力[：:]\s*(.+?)[\n\r]/);
+		if (inputMatch) extraParts.push('入力: ' + inputMatch[1].trim());
+
+		var proofMatch = bibText.match(/校正[：:]\s*(.+?)[\n\r]/);
+		if (proofMatch) extraParts.push('校正: ' + proofMatch[1].trim());
+	}
+
+	if (extraParts.length > 0) {
+		item.extra = extraParts.join('\n');
+	}
+
+	// Extract full text from .main_text
+	var mainText = doc.querySelector('.main_text');
+	if (mainText) {
+		var plainText = extractPlainText(mainText);
+		var markdownText = convertToMarkdown(mainText, item.title, authorName);
+
+		// Save full text as TXT note
+		if (plainText) {
+			item.notes.push({
+				note: '<h1>' + escapeHTML(item.title) + '.txt</h1><pre>'
+					+ escapeHTML(plainText) + '</pre>'
+			});
+		}
+
+		// Save full text as Markdown note
+		if (markdownText) {
+			item.notes.push({
+				note: '<h1>' + escapeHTML(item.title) + '.md</h1><pre>'
+					+ escapeHTML(markdownText) + '</pre>'
+			});
+		}
+	}
+
+	item.complete();
+}
+
+function escapeHTML(str) {
+	return str
+		.replace(/&/g, '&amp;')
+		.replace(/</g, '&lt;')
+		.replace(/>/g, '&gt;')
+		.replace(/"/g, '&quot;');
+}
+
+function extractPlainText(el) {
+	// Clone to avoid modifying original
+	var clone = el.cloneNode(true);
+
+	// Convert ruby to "漢字(かんじ)" format
+	var rubies = clone.querySelectorAll('ruby');
+	for (var i = 0; i < rubies.length; i++) {
+		var rb = rubies[i].querySelector('rb');
+		var rt = rubies[i].querySelector('rt');
+		var base = rb ? rb.textContent : '';
+		var reading = rt ? rt.textContent : '';
+		var replacement = reading ? base + '(' + reading + ')' : base;
+		rubies[i].textContent = replacement;
+	}
+
+	// Remove rp tags (already handled by ruby conversion)
+	var rps = clone.querySelectorAll('rp');
+	for (var j = 0; j < rps.length; j++) {
+		rps[j].textContent = '';
+	}
+
+	// Get text, clean up excessive whitespace
+	var text = clone.textContent;
+	// Remove leading/trailing whitespace
+	text = text.replace(/^[\s\u3000]+/, '').replace(/[\s\u3000]+$/, '');
+	// Normalize line breaks
+	text = text.replace(/\n{3,}/g, '\n\n');
+	return text;
+}
+
+function convertToMarkdown(el, title, author) {
+	var clone = el.cloneNode(true);
+
+	// Convert ruby to "漢字(かんじ)" format
+	var rubies = clone.querySelectorAll('ruby');
+	for (var i = 0; i < rubies.length; i++) {
+		var rb = rubies[i].querySelector('rb');
+		var rt = rubies[i].querySelector('rt');
+		var base = rb ? rb.textContent : '';
+		var reading = rt ? rt.textContent : '';
+		var replacement = reading ? base + '(' + reading + ')' : base;
+		rubies[i].textContent = replacement;
+	}
+
+	// Remove rp tags
+	var rps = clone.querySelectorAll('rp');
+	for (var j = 0; j < rps.length; j++) {
+		rps[j].textContent = '';
+	}
+
+	// Convert <br> to newlines
+	var brs = clone.querySelectorAll('br');
+	for (var k = 0; k < brs.length; k++) {
+		brs[k].textContent = '\n';
+	}
+
+	// Convert <strong> to **text**
+	var strongs = clone.querySelectorAll('strong');
+	for (var m = 0; m < strongs.length; m++) {
+		strongs[m].textContent = '**' + strongs[m].textContent + '**';
+	}
+
+	// Convert <p> to paragraphs
+	var ps = clone.querySelectorAll('p');
+	for (var n = 0; n < ps.length; n++) {
+		ps[n].textContent = '\n\n' + ps[n].textContent + '\n\n';
+	}
+
+	// Get text
+	var text = clone.textContent;
+	// Clean up
+	text = text.replace(/^[\s\u3000]+/, '').replace(/[\s\u3000]+$/, '');
+	text = text.replace(/\n{3,}/g, '\n\n');
+
+	// Build Markdown with header
+	var md = '# ' + title + '\n\n';
+	if (author) {
+		md += '**' + author + '**\n\n';
+	}
+	md += '---\n\n';
+	md += text;
+
+	return md;
+}
+
+
+/** BEGIN TEST CASES **/
+var testCases = [
+	{
+		"type": "web",
+		"url": "https://www.aozora.gr.jp/cards/000879/files/4872_21839.html",
+		"items": [
+			{
+				"itemType": "book",
+				"title": "愛読書の印象",
+				"creators": [],
+				"language": "ja",
+				"libraryCatalog": "青空文庫",
+				"url": "https://www.aozora.gr.jp/cards/000879/files/4872_21839.html",
+				"attachments": [],
+				"tags": [],
+				"notes": [],
+				"seeAlso": []
+			}
+		]
+	}
+]
+/** END TEST CASES **/

--- a/CADAL.js
+++ b/CADAL.js
@@ -1,0 +1,416 @@
+{
+	"translatorID": "a7c8d9e0-f1a2-3b4c-5d6e-7f8a9b0c1d2e",
+	"label": "CADAL",
+	"creator": "Zotero User",
+	"target": "^https?://cadal\\.edu\\.cn/(cardpage/bookCardPage|cadalinfo/search)",
+	"minVersion": "5.0",
+	"maxVersion": "",
+	"priority": 100,
+	"inRepository": true,
+	"translatorType": 4,
+	"browserSupport": "gcsibv",
+	"lastUpdated": "2026-07-15 00:00:00"
+}
+
+/*
+	***** BEGIN LICENSE BLOCK *****
+
+	Copyright © 2026 Zotero User
+
+	This file is part of Zotero.
+
+	Zotero is free software: you can redistribute it and/or modify
+	it under the terms of the GNU Affero General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	Zotero is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+	GNU Affero General Public License for more details.
+
+	You should have received a copy of the GNU Affero General Public License
+	along with Zotero. If not, see <http://www.gnu.org/licenses/>.
+
+	***** END LICENSE BLOCK *****
+*/
+
+function detectWeb(doc, url) {
+	// 详情页
+	if (/cardpage\/bookCardPage/.test(url)) {
+		if (doc.querySelector('span.title')) {
+			return detectType(doc);
+		}
+		return false;
+	}
+	// 搜索结果页
+	if (/cadalinfo\/search/.test(url) && getSearchResults(doc, true)) {
+		return 'multiple';
+	}
+	return false;
+}
+
+function detectType(doc) {
+	var fields = getDDFields(doc);
+	var resourceType = getField(fields, '资源类型');
+	if (/学位论文/.test(resourceType)) return 'thesis';
+	if (/标准/.test(resourceType)) return 'standard';
+	if (/期刊/.test(resourceType)) return 'journalArticle';
+	if (/会议/.test(resourceType)) return 'conferencePaper';
+	if (/专利/.test(resourceType)) return 'patent';
+	return 'book';
+}
+
+function getSearchResults(doc, checkOnly) {
+	var items = {};
+	var found = false;
+	// 搜索结果项: <a class="title" onclick="bookCardPageGo('ssno','card')">
+	var titleLinks = doc.querySelectorAll('a.title');
+	for (var i = 0; i < titleLinks.length; i++) {
+		var onclick = titleLinks[i].getAttribute('onclick') || '';
+		var match = onclick.match(/bookCardPageGo\(['"]([^'"]+)['"]/);
+		if (!match) continue;
+		var ssno = match[1];
+		var url = 'https://cadal.edu.cn/cardpage/bookCardPage?ssno=' + ssno + '&source=card';
+		var title = ZU.trimInternal(titleLinks[i].textContent);
+		if (!title) continue;
+		if (checkOnly) return true;
+		found = true;
+		items[url] = title;
+	}
+	return found ? items : false;
+}
+
+async function doWeb(doc, url) {
+	if (detectWeb(doc, url) === 'multiple') {
+		var searchResults = getSearchResults(doc, false);
+		var items = await Z.selectItems(searchResults);
+		if (!items) return;
+		for (var itemUrl in items) {
+			var itemDoc = await requestDocument(itemUrl);
+			scrape(itemDoc, itemUrl);
+		}
+	}
+	else {
+		scrape(doc, url);
+	}
+}
+
+function scrape(doc, url) {
+	var itemType = detectType(doc);
+	var item = new Zotero.Item(itemType);
+
+	item.url = url;
+	item.libraryCatalog = '大学数字图书馆国际合作计划';
+	item.language = 'zh-CN';
+
+	// 标题
+	var titleEl = doc.querySelector('span.title');
+	if (titleEl) {
+		item.title = ZU.trimInternal(titleEl.textContent);
+	}
+
+	// 获取所有 <dd> 字段
+	var fields = getDDFields(doc);
+
+	// 作者
+	var author = getField(fields, '作者');
+	if (author) addCreators(item, author);
+
+	// 出版社 / 学位授予单位
+	var publisher = getField(fields, '出版社');
+	if (publisher) {
+		if (itemType === 'thesis') {
+			item.university = publisher;
+		}
+		else {
+			// 处理 "出版社·出版地" 格式
+			var pubParts = publisher.split(/[·・]/);
+			if (pubParts.length >= 2) {
+				item.publisher = pubParts[0].trim();
+				item.place = pubParts[pubParts.length - 1].trim();
+			}
+			else {
+				item.publisher = publisher;
+			}
+		}
+	}
+
+	// 出版时间
+	var date = getField(fields, '出版时间');
+	if (date) item.date = date;
+
+	// ISBN
+	var isbn = getField(fields, 'ISBN');
+	if (isbn) {
+		var isbnMatch = isbn.match(/([\dXx-]{10,})/);
+		if (isbnMatch) item.ISBN = isbnMatch[1];
+	}
+
+	// 摘要
+	var abstract = getAbstract(doc);
+	if (abstract) item.abstractNote = abstract;
+
+	// 标签
+	var tags = getField(fields, '标签');
+	if (tags) {
+		item.tags = tags.split(/[,，;；]/).map(function (t) {
+			return t.trim();
+		}).filter(function (t) {
+			return t && t !== '添加标签';
+		});
+	}
+
+	// 主题（学位论文常见）
+	var subject = getField(fields, '主题');
+	if (subject) {
+		var subjectTags = subject.split(/[；;]/).map(function (t) {
+			return t.trim();
+		}).filter(function (t) {
+			return t;
+		});
+		for (var i = 0; i < subjectTags.length; i++) {
+			if (item.tags.indexOf(subjectTags[i]) === -1) {
+				item.tags.push(subjectTags[i]);
+			}
+		}
+	}
+
+	// 馆藏单位
+	var library = getField(fields, '馆藏单位');
+	var extraParts = [];
+	if (library) {
+		extraParts.push('馆藏单位: ' + library);
+	}
+
+	// 资源类型
+	var resourceType = getField(fields, '资源类型');
+	if (resourceType) {
+		extraParts.push('资源类型: ' + resourceType);
+	}
+
+	if (extraParts.length > 0) {
+		item.extra = extraParts.join('\n');
+	}
+
+	if (itemType === 'thesis') {
+		item.thesisType = '学位论文';
+	}
+
+	item.complete();
+}
+
+// 获取包含标题的主 <dl> 元素
+function getMainDL(doc) {
+	var titleEl = doc.querySelector('span.title');
+	if (titleEl) {
+		var node = titleEl;
+		while (node && node.tagName !== 'DL') {
+			node = node.parentElement;
+		}
+		if (node) return node;
+	}
+	return doc.querySelector('dl');
+}
+
+// 从 <dd> 元素中提取字段
+function getDDFields(doc) {
+	var fields = {};
+	var dl = getMainDL(doc);
+	if (!dl) return fields;
+
+	var ddEls = dl.querySelectorAll('dd');
+	for (var i = 0; i < ddEls.length; i++) {
+		var dd = ddEls[i];
+		// 跳过操作按钮区域
+		if (dd.className && /tool/.test(dd.className)) continue;
+
+		var text = dd.textContent;
+		// 匹配 "标签：值" 格式（中文冒号或英文冒号）
+		var match = text.match(/^([\u4e00-\u9fa5A-Za-z]+)[：:]\s*([\s\S]*)$/);
+		if (match) {
+			var label = match[1].trim();
+			var value = match[2].trim();
+			// 清理标签字段中的"添加标签"链接文字
+			if (label === '标签') {
+				value = value.replace(/添加标签/g, '').trim();
+			}
+			if (value) fields[label] = value;
+		}
+	}
+	return fields;
+}
+
+function getField(fields, labels) {
+	if (!Array.isArray(labels)) labels = [labels];
+	// 第一轮：精确匹配
+	for (var i = 0; i < labels.length; i++) {
+		if (fields[labels[i]]) return fields[labels[i]];
+	}
+	// 第二轮：模糊匹配
+	for (var j = 0; j < labels.length; j++) {
+		var re = new RegExp(labels[j]);
+		for (var key in fields) {
+			if (re.test(key)) return fields[key];
+		}
+	}
+	return '';
+}
+
+// 提取摘要（处理展开/收起机制）
+function getAbstract(doc) {
+	var dl = getMainDL(doc);
+	if (!dl) return '';
+
+	var ddEls = dl.querySelectorAll('dd');
+	for (var i = 0; i < ddEls.length; i++) {
+		var text = ddEls[i].textContent.trim();
+		if (/^说明[：:]/.test(text)) {
+			// 克隆节点并移除链接，合并展开/收起内容
+			var clone = ddEls[i].cloneNode(true);
+			var links = clone.querySelectorAll('a');
+			for (var j = 0; j < links.length; j++) {
+				links[j].remove();
+			}
+			var abstract = ZU.trimInternal(clone.textContent);
+			// 移除 "说明：" 前缀
+			abstract = abstract.replace(/^说明[：:]\s*/, '');
+			return abstract;
+		}
+	}
+	return '';
+}
+
+// 解析作者（处理多作者、国籍前缀、角色标识）
+function addCreators(item, authorString) {
+	if (!authorString) return;
+
+	// 按中英文分号/逗号分割，但不分割括号内的逗号
+	var names = authorString.split(/[,，;；](?![^(]*\))/);
+
+	for (var i = 0; i < names.length; i++) {
+		var name = names[i].trim();
+		if (!name) continue;
+
+		// 移除国籍前缀，如 (苏联)、(澳)
+		name = name.replace(/^\([\u4e00-\u9fa5]{1,5}\)\s*/, '');
+
+		// 移除括号内的角色标识，如 (著)、(编)、(译)
+		name = name.replace(/\([著编译辑撰注校订整理主编]+\)/g, '').trim();
+
+		// 移除末尾角色字符，如 著、编、译
+		name = name.replace(/[著编译辑撰注校订整理主编]+$/, '').trim();
+
+		if (!name) continue;
+
+		// 处理括号内的西文名
+		var westernMatch = name.match(/\(([A-Za-z][^)]+)\)/);
+		if (westernMatch) {
+			var creator = ZU.cleanAuthor(westernMatch[1], 'author');
+			if (creator.lastName) {
+				item.creators.push(creator);
+				continue;
+			}
+		}
+
+		// 移除剩余括号内容（用于中文名清理）
+		name = name.replace(/\([^)]*\)/g, '').trim();
+		if (!name) continue;
+
+		if (/[\u4e00-\u9fa5]/.test(name)) {
+			// 中文名：单字段模式
+			item.creators.push({
+				lastName: name,
+				creatorType: 'author',
+				fieldMode: 1
+			});
+		}
+		else {
+			// 西文名：解析为姓+名
+			var creator2 = ZU.cleanAuthor(name, 'author');
+			if (creator2.lastName) {
+				item.creators.push(creator2);
+			}
+		}
+	}
+}
+
+
+/** BEGIN TEST CASES **/
+var testCases = [
+	{
+		"type": "web",
+		"url": "https://cadal.edu.cn/cardpage/bookCardPage?ssno=SD297043500&source=card",
+		"items": [
+			{
+				"itemType": "book",
+				"title": "重写翻译史",
+				"creators": [
+					{
+						"lastName": "谢天振",
+						"creatorType": "author",
+						"fieldMode": 1
+					}
+				],
+				"ISBN": "9787308212533",
+				"language": "zh-CN",
+				"libraryCatalog": "大学数字图书馆国际合作计划",
+				"publisher": "浙江大学出版社",
+				"date": "2021-04-12",
+				"url": "https://cadal.edu.cn/cardpage/bookCardPage?ssno=SD297043500&source=card",
+				"attachments": [],
+				"tags": [],
+				"notes": [],
+				"seeAlso": []
+			}
+		]
+	},
+	{
+		"type": "web",
+		"url": "https://cadal.edu.cn/cardpage/bookCardPage?ssno=03033710&source=card",
+		"items": [
+			{
+				"itemType": "thesis",
+				"title": "文化转型：鲁迅在中国近现代翻译史上的地位与意义",
+				"creators": [
+					{
+						"lastName": "雷亚平",
+						"creatorType": "author",
+						"fieldMode": 1
+					}
+				],
+				"language": "zh-CN",
+				"libraryCatalog": "大学数字图书馆国际合作计划",
+				"university": "吉林大学",
+				"thesisType": "学位论文",
+				"date": "1999-12",
+				"url": "https://cadal.edu.cn/cardpage/bookCardPage?ssno=03033710&source=card",
+				"attachments": [],
+				"tags": [
+					"文化",
+					"转型",
+					"鲁迅",
+					"中国",
+					"近现代",
+					"翻译",
+					"史上",
+					"意义",
+					"吉林",
+					"九十年代",
+					"专著",
+					"中国近现代翻译史",
+					"中国文化转型",
+					"鲁迅"
+				],
+				"notes": [],
+				"seeAlso": []
+			}
+		]
+	},
+	{
+		"type": "web",
+		"url": "https://cadal.edu.cn/cadalinfo/search?searchType=sw&leftSearchContent=翻译史",
+		"items": "multiple"
+	}
+]
+/** END TEST CASES **/

--- a/CADAL.js
+++ b/CADAL.js
@@ -1,7 +1,7 @@
 {
-	"translatorID": "a7c8d9e0-f1a2-3b4c-5d6e-7f8a9b0c1d2e",
+	"translatorID": "1c209d20-79a7-4602-89ea-f83f4bb16a81",
 	"label": "CADAL",
-	"creator": "Zotero User",
+	"creator": "Daxoel",
 	"target": "^https?://cadal\\.edu\\.cn/(cardpage/bookCardPage|cadalinfo/search)",
 	"minVersion": "5.0",
 	"maxVersion": "",
@@ -9,13 +9,13 @@
 	"inRepository": true,
 	"translatorType": 4,
 	"browserSupport": "gcsibv",
-	"lastUpdated": "2026-07-15 00:00:00"
+	"lastUpdated": "2026-08-18 10:00:00"
 }
 
 /*
 	***** BEGIN LICENSE BLOCK *****
 
-	Copyright © 2026 Zotero User
+	Copyright © 2026 4965898
 
 	This file is part of Zotero.
 
@@ -51,8 +51,8 @@ function detectWeb(doc, url) {
 }
 
 function detectType(doc) {
-	var fields = getDDFields(doc);
-	var resourceType = getField(fields, '资源类型');
+	const fields = getDDFields(doc);
+	const resourceType = getField(fields, '资源类型');
 	if (/学位论文/.test(resourceType)) return 'thesis';
 	if (/标准/.test(resourceType)) return 'standard';
 	if (/期刊/.test(resourceType)) return 'journalArticle';
@@ -62,17 +62,17 @@ function detectType(doc) {
 }
 
 function getSearchResults(doc, checkOnly) {
-	var items = {};
-	var found = false;
+	const items = {};
+	let found = false;
 	// 搜索结果项: <a class="title" onclick="bookCardPageGo('ssno','card')">
-	var titleLinks = doc.querySelectorAll('a.title');
-	for (var i = 0; i < titleLinks.length; i++) {
-		var onclick = titleLinks[i].getAttribute('onclick') || '';
-		var match = onclick.match(/bookCardPageGo\(['"]([^'"]+)['"]/);
+	const titleLinks = doc.querySelectorAll('a.title');
+	for (const titleLink of titleLinks) {
+		const onclick = titleLink.getAttribute('onclick') || '';
+		const match = onclick.match(/bookCardPageGo\(['"]([^'"]+)['"]/);
 		if (!match) continue;
-		var ssno = match[1];
-		var url = 'https://cadal.edu.cn/cardpage/bookCardPage?ssno=' + ssno + '&source=card';
-		var title = ZU.trimInternal(titleLinks[i].textContent);
+		const ssno = match[1];
+		const url = 'https://cadal.edu.cn/cardpage/bookCardPage?ssno=' + ssno + '&source=card';
+		const title = ZU.trimInternal(titleLink.textContent);
 		if (!title) continue;
 		if (checkOnly) return true;
 		found = true;
@@ -83,11 +83,11 @@ function getSearchResults(doc, checkOnly) {
 
 async function doWeb(doc, url) {
 	if (detectWeb(doc, url) === 'multiple') {
-		var searchResults = getSearchResults(doc, false);
-		var items = await Z.selectItems(searchResults);
+		const searchResults = getSearchResults(doc, false);
+		const items = await Z.selectItems(searchResults);
 		if (!items) return;
-		for (var itemUrl in items) {
-			var itemDoc = await requestDocument(itemUrl);
+		for (const itemUrl in items) {
+			const itemDoc = await requestDocument(itemUrl);
 			scrape(itemDoc, itemUrl);
 		}
 	}
@@ -97,35 +97,35 @@ async function doWeb(doc, url) {
 }
 
 function scrape(doc, url) {
-	var itemType = detectType(doc);
-	var item = new Zotero.Item(itemType);
+	const itemType = detectType(doc);
+	const item = new Z.Item(itemType);
 
 	item.url = url;
 	item.libraryCatalog = '大学数字图书馆国际合作计划';
 	item.language = 'zh-CN';
 
 	// 标题
-	var titleEl = doc.querySelector('span.title');
+	const titleEl = doc.querySelector('span.title');
 	if (titleEl) {
 		item.title = ZU.trimInternal(titleEl.textContent);
 	}
 
 	// 获取所有 <dd> 字段
-	var fields = getDDFields(doc);
+	const fields = getDDFields(doc);
 
 	// 作者
-	var author = getField(fields, '作者');
+	const author = getField(fields, '作者');
 	if (author) addCreators(item, author);
 
 	// 出版社 / 学位授予单位
-	var publisher = getField(fields, '出版社');
+	const publisher = getField(fields, '出版社');
 	if (publisher) {
 		if (itemType === 'thesis') {
 			item.university = publisher;
 		}
 		else {
 			// 处理 "出版社·出版地" 格式
-			var pubParts = publisher.split(/[·・]/);
+			const pubParts = publisher.split(/[·・]/);
 			if (pubParts.length >= 2) {
 				item.publisher = pubParts[0].trim();
 				item.place = pubParts[pubParts.length - 1].trim();
@@ -137,22 +137,22 @@ function scrape(doc, url) {
 	}
 
 	// 出版时间
-	var date = getField(fields, '出版时间');
+	const date = getField(fields, '出版时间');
 	if (date) item.date = date;
 
 	// ISBN
-	var isbn = getField(fields, 'ISBN');
+	const isbn = getField(fields, 'ISBN');
 	if (isbn) {
-		var isbnMatch = isbn.match(/([\dXx-]{10,})/);
+		const isbnMatch = isbn.match(/([\dXx-]{10,})/);
 		if (isbnMatch) item.ISBN = isbnMatch[1];
 	}
 
 	// 摘要
-	var abstract = getAbstract(doc);
+	const abstract = getAbstract(doc);
 	if (abstract) item.abstractNote = abstract;
 
 	// 标签
-	var tags = getField(fields, '标签');
+	const tags = getField(fields, '标签');
 	if (tags) {
 		item.tags = tags.split(/[,，;；]/).map(function (t) {
 			return t.trim();
@@ -162,29 +162,29 @@ function scrape(doc, url) {
 	}
 
 	// 主题（学位论文常见）
-	var subject = getField(fields, '主题');
+	const subject = getField(fields, '主题');
 	if (subject) {
-		var subjectTags = subject.split(/[；;]/).map(function (t) {
+		const subjectTags = subject.split(/[；;]/).map(function (t) {
 			return t.trim();
 		}).filter(function (t) {
 			return t;
 		});
-		for (var i = 0; i < subjectTags.length; i++) {
-			if (item.tags.indexOf(subjectTags[i]) === -1) {
-				item.tags.push(subjectTags[i]);
+		for (const subjectTag of subjectTags) {
+			if (item.tags.indexOf(subjectTag) === -1) {
+				item.tags.push(subjectTag);
 			}
 		}
 	}
 
 	// 馆藏单位
-	var library = getField(fields, '馆藏单位');
-	var extraParts = [];
+	const library = getField(fields, '馆藏单位');
+	const extraParts = [];
 	if (library) {
 		extraParts.push('馆藏单位: ' + library);
 	}
 
 	// 资源类型
-	var resourceType = getField(fields, '资源类型');
+	const resourceType = getField(fields, '资源类型');
 	if (resourceType) {
 		extraParts.push('资源类型: ' + resourceType);
 	}
@@ -202,9 +202,9 @@ function scrape(doc, url) {
 
 // 获取包含标题的主 <dl> 元素
 function getMainDL(doc) {
-	var titleEl = doc.querySelector('span.title');
+	const titleEl = doc.querySelector('span.title');
 	if (titleEl) {
-		var node = titleEl;
+		let node = titleEl;
 		while (node && node.tagName !== 'DL') {
 			node = node.parentElement;
 		}
@@ -215,22 +215,21 @@ function getMainDL(doc) {
 
 // 从 <dd> 元素中提取字段
 function getDDFields(doc) {
-	var fields = {};
-	var dl = getMainDL(doc);
+	const fields = {};
+	const dl = getMainDL(doc);
 	if (!dl) return fields;
 
-	var ddEls = dl.querySelectorAll('dd');
-	for (var i = 0; i < ddEls.length; i++) {
-		var dd = ddEls[i];
+	const ddEls = dl.querySelectorAll('dd');
+	for (const dd of ddEls) {
 		// 跳过操作按钮区域
 		if (dd.className && /tool/.test(dd.className)) continue;
 
-		var text = dd.textContent;
+		const text = dd.textContent;
 		// 匹配 "标签：值" 格式（中文冒号或英文冒号）
-		var match = text.match(/^([\u4e00-\u9fa5A-Za-z]+)[：:]\s*([\s\S]*)$/);
+		const match = text.match(/^([\u4e00-\u9fa5A-Za-z]+)[：:]\s*([\s\S]*)$/);
 		if (match) {
-			var label = match[1].trim();
-			var value = match[2].trim();
+			const label = match[1].trim();
+			let value = match[2].trim();
 			// 清理标签字段中的"添加标签"链接文字
 			if (label === '标签') {
 				value = value.replace(/添加标签/g, '').trim();
@@ -244,13 +243,13 @@ function getDDFields(doc) {
 function getField(fields, labels) {
 	if (!Array.isArray(labels)) labels = [labels];
 	// 第一轮：精确匹配
-	for (var i = 0; i < labels.length; i++) {
-		if (fields[labels[i]]) return fields[labels[i]];
+	for (const label of labels) {
+		if (fields[label]) return fields[label];
 	}
 	// 第二轮：模糊匹配
-	for (var j = 0; j < labels.length; j++) {
-		var re = new RegExp(labels[j]);
-		for (var key in fields) {
+	for (const label of labels) {
+		const re = new RegExp(label);
+		for (const key in fields) {
 			if (re.test(key)) return fields[key];
 		}
 	}
@@ -259,20 +258,20 @@ function getField(fields, labels) {
 
 // 提取摘要（处理展开/收起机制）
 function getAbstract(doc) {
-	var dl = getMainDL(doc);
+	const dl = getMainDL(doc);
 	if (!dl) return '';
 
-	var ddEls = dl.querySelectorAll('dd');
-	for (var i = 0; i < ddEls.length; i++) {
-		var text = ddEls[i].textContent.trim();
+	const ddEls = dl.querySelectorAll('dd');
+	for (const dd of ddEls) {
+		const text = dd.textContent.trim();
 		if (/^说明[：:]/.test(text)) {
 			// 克隆节点并移除链接，合并展开/收起内容
-			var clone = ddEls[i].cloneNode(true);
-			var links = clone.querySelectorAll('a');
-			for (var j = 0; j < links.length; j++) {
-				links[j].remove();
+			const clone = dd.cloneNode(true);
+			const links = clone.querySelectorAll('a');
+			for (const link of links) {
+				link.remove();
 			}
-			var abstract = ZU.trimInternal(clone.textContent);
+			let abstract = ZU.trimInternal(clone.textContent);
 			// 移除 "说明：" 前缀
 			abstract = abstract.replace(/^说明[：:]\s*/, '');
 			return abstract;
@@ -286,10 +285,10 @@ function addCreators(item, authorString) {
 	if (!authorString) return;
 
 	// 按中英文分号/逗号分割，但不分割括号内的逗号
-	var names = authorString.split(/[,，;；](?![^(]*\))/);
+	const names = authorString.split(/[,，;；](?![^(]*\))/);
 
-	for (var i = 0; i < names.length; i++) {
-		var name = names[i].trim();
+	for (const rawName of names) {
+		let name = rawName.trim();
 		if (!name) continue;
 
 		// 移除国籍前缀，如 (苏联)、(澳)
@@ -304,9 +303,9 @@ function addCreators(item, authorString) {
 		if (!name) continue;
 
 		// 处理括号内的西文名
-		var westernMatch = name.match(/\(([A-Za-z][^)]+)\)/);
+		const westernMatch = name.match(/\(([A-Za-z][^)]+)\)/);
 		if (westernMatch) {
-			var creator = ZU.cleanAuthor(westernMatch[1], 'author');
+			const creator = ZU.cleanAuthor(westernMatch[1], 'author');
 			if (creator.lastName) {
 				item.creators.push(creator);
 				continue;
@@ -327,7 +326,7 @@ function addCreators(item, authorString) {
 		}
 		else {
 			// 西文名：解析为姓+名
-			var creator2 = ZU.cleanAuthor(name, 'author');
+			const creator2 = ZU.cleanAuthor(name, 'author');
 			if (creator2.lastName) {
 				item.creators.push(creator2);
 			}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,32 @@
+# 更新日志 (CHANGELOG)
+
+本文件记录本仓库中由 [@Daxoel](https://github.com/4965898) 开发维护的翻译器更新历史。
+
+## 2026-08-18
+
+### 翻译器现代化重构
+
+根据 [PR #939](https://github.com/l0o0/translators_CN/pull/939) 中维护者的审阅意见，对以下翻译器进行了全面现代化重构：
+
+- **移除已废弃的 FW 框架依赖**（Wikimedia Commons.js）
+- **将 `var` 声明现代化为 `const`/`let`**
+- **移除 `ZU.processDocuments`、`ZU.doGet` 等旧 API**，改用现代 Promise API（`requestJSON`、`requestText`、`requestDocument`、`processDocuments`）
+- **修正 creator 字段**（CNBKSY V2.js 的 creator 由 jiaojiaodubai 修正为 Daxoel）
+
+涉及文件：
+
+| 文件 | 主要变更 |
+|------|---------|
+| [CADAL.js](./CADAL.js) | var→const/let，改用 `requestDocument`/`Z.selectItems`，creator 修正 |
+| [CNBKSY V2.js](./CNBKSY%20V2.js) | var→const/let，改用现代 API，creator 修正为 Daxoel |
+| [China National Library - Republic Era.js](./China%20National%20Library%20-%20Republic%20Era.js) | var→const/let，改用 `processDocuments`/`Z.selectItems`，creator 修正 |
+| [China National Library - Modern Newspaper Database.js](./China%20National%20Library%20-%20Modern%20Newspaper%20Database.js) | var→const/let，改用 `Z.selectItems`，creator 修正 |
+| [ShuKui.js](./ShuKui.js) | var→const/let，改用 `processDocuments`/`Z.selectItems`，creator 修正 |
+| [Wikimedia Commons.js](./Wikimedia%20Commons.js) | 移除 FW 框架，重写为原生 DOM/API 解析，var→const/let，改用 `requestJSON`/`requestText`，creator 修正 |
+
+### Wikimedia Commons.js 功能增强
+
+- 重写 `getWikitext`：使用 `requestJSON`（现代 API），失败时回退到 `requestText`
+- 重写 `scrapeBookFromDOM`：使用 `fileinfotpl_*` ID 直接提取元数据，不再依赖文本匹配
+- 支持 `{{Book}}`/`{{Information}}` 模板解析，提取标题、作者、出版社、出版地、日期、ISBN、版次、页数、DOI 等完整元数据
+- 支持 PDF/DjVu 附件，特别支持超星爬取的中文民国书籍与古籍

--- a/CNBKSY V2.js
+++ b/CNBKSY V2.js
@@ -1,7 +1,7 @@
-﻿{
+{
 	"translatorID": "a3b4c5d6-e7f8-4a90-bcde-f12345678901",
 	"label": "CNBKSY V2",
-	"creator": "jiaojiaodubai",
+	"creator": "Daxoel",
 	"target": "^https?://(www\\.)?cnbksy\\.com/v2",
 	"minVersion": "5.0",
 	"maxVersion": "",
@@ -9,13 +9,13 @@
 	"inRepository": true,
 	"translatorType": 4,
 	"browserSupport": "gcsibv",
-	"lastUpdated": "2026-08-04 00:00:00"
+	"lastUpdated": "2026-08-18 10:53:57"
 }
 
 /*
 	***** BEGIN LICENSE BLOCK *****
 
-	Copyright © 2024 jiaojiaodubai23@gmail.com
+	Copyright © 2026 4965898
 
 	This file is part of Zotero.
 
@@ -65,15 +65,15 @@ function detectWeb(doc, url) {
 }
 
 function getSearchResults(doc, checkOnly) {
-	var items = {};
-	var found = false;
-	var rows = doc.querySelectorAll('tr.ant-table-row[data-row-key]');
-	for (let row of rows) {
-		let id = row.getAttribute('data-row-key');
-		let titleEl = row.querySelector('.titleBox a.cpHover');
+	const items = {};
+	let found = false;
+	const rows = doc.querySelectorAll('tr.ant-table-row[data-row-key]');
+	for (const row of rows) {
+		const id = row.getAttribute('data-row-key');
+		const titleEl = row.querySelector('.titleBox a.cpHover');
 		if (!id || !titleEl) continue;
 		// textContent 自动忽略 <font class="highLight"> 标签，拼接出纯文本标题
-		let title = ZU.trimInternal(titleEl.textContent);
+		const title = ZU.trimInternal(titleEl.textContent);
 		if (!title) continue;
 		if (checkOnly) return true;
 		found = true;
@@ -85,7 +85,7 @@ function getSearchResults(doc, checkOnly) {
 
 async function doWeb(doc, url) {
 	if (detectWeb(doc, url) == 'multiple') {
-		let items = await Zotero.selectItems(getSearchResults(doc, false));
+		let items = await Z.selectItems(getSearchResults(doc, false));
 		if (!items) return;
 		// SPA 页面 requestDocument 会拿到未渲染的外壳，改为直接从搜索结果页 DOM 提取元数据
 		for (let id of Object.keys(items)) {
@@ -99,17 +99,17 @@ async function doWeb(doc, url) {
 
 // 从搜索结果页 DOM 直接提取单条元数据（避免 SPA 外壳问题）
 function scrapeFromSearch(doc, id) {
-	var row = doc.querySelector(`tr.ant-table-row[data-row-key="${id}"]`);
+	const row = doc.querySelector(`tr.ant-table-row[data-row-key="${id}"]`);
 	if (!row) return;
-	var timeBox = row.querySelector('.timeBox');
+	const timeBox = row.querySelector('.timeBox');
 	if (!timeBox) return;
 	// timeBox 文本格式：
 	//   期刊："作者 《刊名》 1922 年 [ 第1卷 第3期 ，1-2页 ]"
 	//   报纸："作者 《报名》 1945 年 10 月 9 日 [0004版]"
-	var timeText = ZU.trimInternal(timeBox.textContent);
-	var bracket = tryMatch(timeText, /\[([^\]]*)\]/);
+	const timeText = ZU.trimInternal(timeBox.textContent);
+	const bracket = tryMatch(timeText, /\[([^\]]*)\]/);
 
-	var type;
+	let type;
 	if (/卷.*期/.test(bracket)) {
 		type = 'journalArticle';
 	}
@@ -121,7 +121,7 @@ function scrapeFromSearch(doc, id) {
 		type = 'journalArticle';
 	}
 
-	var newItem = new Z.Item(type);
+	const newItem = new Z.Item(type);
 	// 标题
 	newItem.title = ZU.trimInternal(row.querySelector('.titleBox a.cpHover').textContent);
 	// 作者与文献来源：遍历 .timeBox 内所有 cpHover 链接
@@ -129,9 +129,9 @@ function scrapeFromSearch(doc, id) {
 	//   含"卷/期/版/页"的是卷期信息，跳过
 	//   其余是作者（多作者时第二个作者可能没有 authorMarginR class）
 	//   若一个链接文本含空格分隔的多个名字，按空格拆分（需 DOM 确认）
-	var cpHoverLinks = row.querySelectorAll('.timeBox a.cpHover');
-	for (let link of cpHoverLinks) {
-		let text = ZU.trimInternal(link.textContent);
+	const cpHoverLinks = row.querySelectorAll('.timeBox a.cpHover');
+	for (const link of cpHoverLinks) {
+		const text = ZU.trimInternal(link.textContent);
 		if (/[《》]/.test(text)) {
 			// 文献来源
 			newItem.publicationTitle = text.replace(/^《|》$/g, '').trim();
@@ -159,8 +159,8 @@ function scrapeFromSearch(doc, id) {
 	}
 	// PDF 附件：根据文章类型推断 lcPieceTypeId（期刊=7，报纸=12）
 	// activeId 用 undefined（之前详情页测试确认非必需）
-	var lcPieceTypeId = (type === 'journalArticle') ? '7' : '12';
-	var pdfUrl = `https://${doc.location.host}/api/v2/literature/download?downloadSource=GENERALSEARCH&source=DOWNLOAD&lcPieceTypeId=${lcPieceTypeId}&pieceId=${id}&activeId=undefined`;
+	const lcPieceTypeId = (type === 'journalArticle') ? '7' : '12';
+	const pdfUrl = `https://${doc.location.host}/api/v2/literature/download?downloadSource=GENERALSEARCH&source=DOWNLOAD&lcPieceTypeId=${lcPieceTypeId}&pieceId=${id}&activeId=undefined`;
 	newItem.attachments.push({
 		title: 'Full Text PDF',
 		mimeType: 'application/pdf',
@@ -309,5 +309,6 @@ class Labels {
 }
 
 /** BEGIN TEST CASES **/
-var testCases = []
+var testCases = [
+]
 /** END TEST CASES **/

--- a/CNBKSY V2.js
+++ b/CNBKSY V2.js
@@ -1,0 +1,313 @@
+﻿{
+	"translatorID": "a3b4c5d6-e7f8-4a90-bcde-f12345678901",
+	"label": "CNBKSY V2",
+	"creator": "jiaojiaodubai",
+	"target": "^https?://(www\\.)?cnbksy\\.com/v2",
+	"minVersion": "5.0",
+	"maxVersion": "",
+	"priority": 90,
+	"inRepository": true,
+	"translatorType": 4,
+	"browserSupport": "gcsibv",
+	"lastUpdated": "2026-08-04 00:00:00"
+}
+
+/*
+	***** BEGIN LICENSE BLOCK *****
+
+	Copyright © 2024 jiaojiaodubai23@gmail.com
+
+	This file is part of Zotero.
+
+	Zotero is free software: you can redistribute it and/or modify
+	it under the terms of the GNU Affero General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	Zotero is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+	GNU Affero General Public License for more details.
+
+	You should have received a copy of the GNU Affero General Public License
+	along with Zotero. If not, see <http://www.gnu.org/licenses/>.
+
+	***** END LICENSE BLOCK *****
+*/
+
+
+function detectWeb(doc, url) {
+	// 详情页：期刊文章 / 报纸文章
+	if (url.includes('/v2/search/detail')) {
+		if (doc.querySelector('.root_detail .line_data')) {
+			// 区分期刊与报纸：报纸有"标题1"字段，期刊有"题名"字段
+			let dts = doc.querySelectorAll('.line_data dt.lefttitle');
+			for (let dt of dts) {
+				if (/标题1/.test(dt.textContent)) {
+					return 'newspaperArticle';
+				}
+			}
+			return 'journalArticle';
+		}
+		// SPA 未渲染完，监控 DOM 变化
+		Z.monitorDOMChanges(doc.body, { childList: true, subtree: true });
+		return false;
+	}
+	// 搜索结果页
+	else if (url.match(/\/v2\/search(\/ordinary)?(\?|$)/)) {
+		if (doc.querySelector('tr.ant-table-row[data-row-key]')) {
+			return 'multiple';
+		}
+		Z.monitorDOMChanges(doc.body, { childList: true, subtree: true });
+		return false;
+	}
+	return false;
+}
+
+function getSearchResults(doc, checkOnly) {
+	var items = {};
+	var found = false;
+	var rows = doc.querySelectorAll('tr.ant-table-row[data-row-key]');
+	for (let row of rows) {
+		let id = row.getAttribute('data-row-key');
+		let titleEl = row.querySelector('.titleBox a.cpHover');
+		if (!id || !titleEl) continue;
+		// textContent 自动忽略 <font class="highLight"> 标签，拼接出纯文本标题
+		let title = ZU.trimInternal(titleEl.textContent);
+		if (!title) continue;
+		if (checkOnly) return true;
+		found = true;
+		// 用 data-row-key 作为 key（scrapeFromSearch 会用 id 反查 row）
+		items[id] = title;
+	}
+	return found ? items : false;
+}
+
+async function doWeb(doc, url) {
+	if (detectWeb(doc, url) == 'multiple') {
+		let items = await Zotero.selectItems(getSearchResults(doc, false));
+		if (!items) return;
+		// SPA 页面 requestDocument 会拿到未渲染的外壳，改为直接从搜索结果页 DOM 提取元数据
+		for (let id of Object.keys(items)) {
+			scrapeFromSearch(doc, id);
+		}
+	}
+	else {
+		await scrape(doc, url);
+	}
+}
+
+// 从搜索结果页 DOM 直接提取单条元数据（避免 SPA 外壳问题）
+function scrapeFromSearch(doc, id) {
+	var row = doc.querySelector(`tr.ant-table-row[data-row-key="${id}"]`);
+	if (!row) return;
+	var timeBox = row.querySelector('.timeBox');
+	if (!timeBox) return;
+	// timeBox 文本格式：
+	//   期刊："作者 《刊名》 1922 年 [ 第1卷 第3期 ，1-2页 ]"
+	//   报纸："作者 《报名》 1945 年 10 月 9 日 [0004版]"
+	var timeText = ZU.trimInternal(timeBox.textContent);
+	var bracket = tryMatch(timeText, /\[([^\]]*)\]/);
+
+	var type;
+	if (/卷.*期/.test(bracket)) {
+		type = 'journalArticle';
+	}
+	else if (/版/.test(bracket)) {
+		type = 'newspaperArticle';
+	}
+	else {
+		// 默认按期刊处理
+		type = 'journalArticle';
+	}
+
+	var newItem = new Z.Item(type);
+	// 标题
+	newItem.title = ZU.trimInternal(row.querySelector('.titleBox a.cpHover').textContent);
+	// 作者与文献来源：遍历 .timeBox 内所有 cpHover 链接
+	//   含《》的是文献来源
+	//   含"卷/期/版/页"的是卷期信息，跳过
+	//   其余是作者（多作者时第二个作者可能没有 authorMarginR class）
+	//   若一个链接文本含空格分隔的多个名字，按空格拆分（需 DOM 确认）
+	var cpHoverLinks = row.querySelectorAll('.timeBox a.cpHover');
+	for (let link of cpHoverLinks) {
+		let text = ZU.trimInternal(link.textContent);
+		if (/[《》]/.test(text)) {
+			// 文献来源
+			newItem.publicationTitle = text.replace(/^《|》$/g, '').trim();
+		}
+		else if (/卷|期|版|页/.test(text)) {
+			// 卷期信息，跳过
+			continue;
+		}
+		else {
+			// 作者（cleanAuthorElm 会处理后缀"译/记"等角色标记）
+			newItem.creators.push(cleanAuthorElm(link));
+		}
+	}
+	// 日期
+	newItem.date = ZU.strToISO(tryMatch(timeText, /(\d{4}\s*年(\s*\d+\s*月(\s*\d+\s*日)?)?)/));
+
+	if (type === 'journalArticle') {
+		newItem.volume = tryMatch(bracket, /第?0*(\d+)卷/, 1);
+		newItem.issue = tryMatch(bracket, /第?0*(\d+)期/, 1);
+		newItem.pages = tryMatch(bracket, /([\d-.+]*)页/, 1).replace(/[+.]\s?/g, ', ');
+	}
+	else {
+		// 版次格式："0004版" → "4"
+		newItem.pages = tryMatch(bracket, /0*(\d+)版/, 1);
+	}
+	// PDF 附件：根据文章类型推断 lcPieceTypeId（期刊=7，报纸=12）
+	// activeId 用 undefined（之前详情页测试确认非必需）
+	var lcPieceTypeId = (type === 'journalArticle') ? '7' : '12';
+	var pdfUrl = `https://${doc.location.host}/api/v2/literature/download?downloadSource=GENERALSEARCH&source=DOWNLOAD&lcPieceTypeId=${lcPieceTypeId}&pieceId=${id}&activeId=undefined`;
+	newItem.attachments.push({
+		title: 'Full Text PDF',
+		mimeType: 'application/pdf',
+		url: pdfUrl
+	});
+	newItem.url = `https://${doc.location.host}/v2/search/detail?Id=${id}`;
+	newItem.complete();
+}
+
+async function scrape(doc, url = doc.location.href) {
+	const labels = new Labels(doc, '.line_data');
+	const type = detectWeb(doc, url);
+	const newItem = new Z.Item(type);
+	switch (type) {
+		case 'journalArticle': {
+			newItem.title = labels.get('题名');
+			labels.get('作者', true).querySelectorAll('a.router_link').forEach((elm) => {
+				newItem.creators.push(cleanAuthorElm(elm));
+			});
+			newItem.publicationTitle = labels.get('文献来源').replace(/^《|》$/g, '').trim();
+			newItem.date = ZU.strToISO(labels.get('出版时间'));
+			// 卷期格式："第1卷 第3期 ，1-2页"
+			let volIssue = labels.get('卷期');
+			newItem.volume = tryMatch(volIssue, /第?0*(\d+)卷/, 1);
+			newItem.issue = tryMatch(volIssue, /第?0*(\d+)期/, 1);
+			newItem.pages = tryMatch(volIssue, /([\d-.+]*)页/, 1).replace(/[+.]\s?/g, ', ');
+			newItem.abstractNote = labels.get('摘要');
+			let subjects = labels.get('主题词');
+			if (subjects) {
+				newItem.tags = subjects.slice(1, -1).split(/[,;，；]/)
+					.map(element => ({ tag: element.trim() }))
+					.filter(t => t.tag);
+			}
+			break;
+		}
+		case 'newspaperArticle': {
+			newItem.title = labels.get('标题1');
+			newItem.shortTitle = labels.get('标题2');
+			newItem.publicationTitle = labels.get('文献来源').replace(/^《|》$/g, '').trim();
+			newItem.date = ZU.strToISO(labels.get('出版时间'));
+			// 版次格式："0002" → "2"
+			newItem.pages = labels.get('版次').replace(/^0*/, '');
+			labels.get('作者', true).querySelectorAll('a.router_link').forEach((elm) => {
+				newItem.creators.push(cleanAuthorElm(elm));
+			});
+			break;
+		}
+	}
+	// 详情页 URL 含完整参数，可构建 PDF 下载链接
+	addAttachment(doc, newItem, url);
+	newItem.url = url;
+	newItem.complete();
+}
+
+
+// 从详情页 URL 构建 PDF 下载链接
+// 详情页 URL: /v2/search/detail?Id={pieceId}&activeId={activeId}&LiteratureCategoryPieceTypeId={lcPieceTypeId}&...
+// 下载 API:  /api/v2/literature/download?downloadSource=GENERALSEARCH&source=DOWNLOAD&lcPieceTypeId={...}&pieceId={...}&activeId={...}
+function addAttachment(doc, item, url) {
+	try {
+		let u = new URL(url);
+		let pieceId = u.searchParams.get('Id');
+		let activeId = u.searchParams.get('activeId') || 'undefined';
+		let lcPieceTypeId = u.searchParams.get('LiteratureCategoryPieceTypeId');
+		if (!pieceId || !lcPieceTypeId) return;
+		let pdfUrl = `https://${u.host}/api/v2/literature/download?downloadSource=GENERALSEARCH&source=DOWNLOAD&lcPieceTypeId=${lcPieceTypeId}&pieceId=${pieceId}&activeId=${activeId}`;
+		item.attachments.push({
+			title: 'Full Text PDF',
+			mimeType: 'application/pdf',
+			url: pdfUrl
+		});
+	}
+	catch (e) {
+		// URL 解析失败，忽略附件
+	}
+}
+
+
+function cleanAuthorElm(elm) {
+	// 作者链接文本可能含 &nbsp;，ZU.cleanAuthor 会处理
+	// 后继文本节点可能标记角色：译→译者，记→ contributor
+	let creatorType = 'author';
+	if (elm.nextSibling && elm.nextSibling.nodeName == '#text') {
+		let suffix = elm.nextSibling.textContent.trim();
+		if (/^[译譯]$/.test(suffix)) {
+			creatorType = 'translator';
+		}
+		else if (/^[记記]$/.test(suffix)) {
+			creatorType = 'contributor';
+		}
+	}
+	const creator = ZU.cleanAuthor(elm.textContent, creatorType);
+	// 中文姓名不拆分姓/名
+	if (/[\u4e00-\u9fff]/.test(creator.lastName)) {
+		creator.fieldMode = 1;
+	}
+	return creator;
+}
+
+function tryMatch(string, pattern, index = 0) {
+	if (!string) return '';
+	const match = string.match(pattern);
+	return (match && match[index])
+		? match[index]
+		: '';
+}
+
+// V2 字段解析：.line_data > dt.lefttitle + dd.right_content
+class Labels {
+	constructor(doc, selector) {
+		this.data = [];
+		this.emptyElm = doc.createElement('div');
+		const nodes = doc.querySelectorAll(selector);
+		for (const node of nodes) {
+			const dt = node.querySelector('dt.lefttitle');
+			const dd = node.querySelector('dd.right_content');
+			if (!dt || !dd) continue;
+			// 去除标签末尾的冒号（全角/半角）
+			const key = dt.textContent.replace(/[：:]/g, '').trim();
+			this.data.push([key, dd]);
+		}
+	}
+
+	get(label, element = false) {
+		if (Array.isArray(label)) {
+			const results = label.map(aLabel => this.get(aLabel, element));
+			const keyVal = element
+				? results.find(element => !/^\s*$/.test(element.textContent))
+				: results.find(string => string);
+			return keyVal
+				? keyVal
+				: element
+					? this.emptyElm
+					: '';
+		}
+		const pattern = new RegExp(label, 'i');
+		const keyVal = this.data.find(arr => pattern.test(arr[0]));
+		return keyVal
+			? element
+				? keyVal[1]
+				: ZU.trimInternal(keyVal[1].textContent)
+			: element
+				? this.emptyElm
+				: '';
+	}
+}
+
+/** BEGIN TEST CASES **/
+var testCases = []
+/** END TEST CASES **/

--- a/China National Library - Modern Newspaper Database.js
+++ b/China National Library - Modern Newspaper Database.js
@@ -1,0 +1,198 @@
+{
+	"translatorID": "b2c3d4e5-f6a7-8901-bcde-f12345678901",
+	"label": "China National Library - Modern Newspaper Database",
+	"creator": "Zotero User",
+	"target": "^https?://bz-nlcpress-com-s-[0-9]+\\.ycfw\\.library\\.hb\\.cn:[0-9]+/library/publish/default/(PaperSearch|ChengpinHistoryDetail_pic|paperLayoutView_pic|PaperAll)\\.jsp\\?.*",
+	"minVersion": "3.0",
+	"maxVersion": "",
+	"priority": 100,
+	"inRepository": true,
+	"translatorType": 4,
+	"browserSupport": "gcsibv",
+	"lastUpdated": "2026-07-10 19:45:00"
+}
+
+/*
+	***** BEGIN LICENSE BLOCK *****
+
+	Copyright © 2026 Zotero User
+
+	This file is part of Zotero.
+
+	Zotero is free software: you can redistribute it and/or modify
+	it under the terms of the GNU Affero General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	Zotero is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+	GNU Affero General Public License for more details.
+
+	You should have received a copy of the GNU Affero General Public License
+	along with Zotero. If not, see <http://www.gnu.org/licenses/>.
+
+	***** END LICENSE BLOCK *****
+*/
+
+
+function detectWeb(doc, url) {
+	if (url.includes("PaperSearch.jsp") && getSearchResults(doc, true)) {
+		return "multiple";
+	}
+	if ((url.includes("ChengpinHistoryDetail_pic.jsp") || url.includes("paperLayoutView_pic.jsp") || url.includes("PaperAll.jsp")) && doc.querySelector('.newsList02, .art-topic, .newsTitle')) {
+		return "newspaperArticle";
+	}
+	return false;
+}
+
+
+function getSearchResults(doc, checkOnly) {
+	var items = {};
+	var found = false;
+	var rows = doc.querySelectorAll('.newsList02');
+	for (var i = 0; i < rows.length; i++) {
+		var titleLink = rows[i].querySelector('.newsTitle .art-topic');
+		if (!titleLink) continue;
+		var title = titleLink.textContent.trim();
+		var docID = rows[i].getAttribute('docid');
+		if (!title || !docID) continue;
+		if (checkOnly) return true;
+		found = true;
+		items[docID] = title;
+	}
+	return found ? items : false;
+}
+
+
+function doWeb(doc, url) {
+	if (detectWeb(doc, url) == "multiple") {
+		Zotero.selectItems(getSearchResults(doc, false), function (items) {
+			if (!items) return;
+			for (var docID in items) {
+				scrapeItemFromSearchResult(doc, docID, url);
+			}
+		});
+	}
+	else {
+		scrape(doc, url);
+	}
+}
+
+
+function scrapeItemFromSearchResult(doc, docID, url) {
+	var row = doc.querySelector('.newsList02[docid="' + docID + '"]');
+	if (!row) return;
+
+	var item = new Zotero.Item("newspaperArticle");
+
+	// 标题
+	var titleEl = row.querySelector('.newsTitle .art-topic');
+	if (titleEl) {
+		item.title = titleEl.textContent.trim();
+	}
+
+	// 链接
+	var links = row.querySelectorAll('li.newsStyle.right a');
+	var baseURL = url.match(/^(https?:\/\/[^\/]+\/library\/publish\/default\/)/);
+	baseURL = baseURL ? baseURL[1] : "";
+
+	// 报纸名
+	if (links.length > 0) {
+		item.publicationTitle = links[0].textContent.trim();
+	}
+
+	// 日期
+	if (links.length > 1) {
+		item.date = links[1].textContent.trim();
+	}
+
+	// 版次
+	if (links.length > 2) {
+		item.pages = links[2].textContent.trim();
+	}
+
+	// 文章 URL：使用详情页链接（整报浏览或日期链接）
+	if (links.length > 1) {
+		item.url = links[1].href;
+	}
+	else {
+		item.url = url;
+	}
+
+	item.language = "zh-CN";
+	item.libraryCatalog = "中国历史文献总库·近代报纸数据库";
+
+	// PDF 附件
+	var downloadLink = null;
+	var allLinks = row.querySelectorAll('a');
+	for (var i = 0; i < allLinks.length; i++) {
+		var onclickAttr = allLinks[i].getAttribute('onclick');
+		if (onclickAttr && onclickAttr.indexOf('downloadPaper') !== -1) {
+			downloadLink = allLinks[i];
+			break;
+		}
+	}
+	if (downloadLink && baseURL) {
+		var onclickAttr = downloadLink.getAttribute('onclick');
+		if (onclickAttr) {
+			var match = onclickAttr.match(/downloadPaper\('([^']+)'\)/);
+			if (match) {
+				var pdfURL = baseURL + match[1];
+				item.attachments.push({
+					title: "Full Text PDF",
+					url: pdfURL,
+					mimeType: "application/pdf"
+				});
+			}
+		}
+	}
+
+	item.attachments.push({
+		title: "Newspaper Database Record",
+		url: item.url,
+		mimeType: "text/html",
+		snapshot: false
+	});
+
+	item.complete();
+}
+
+
+function scrape(doc, url) {
+	// 详情页抓取逻辑（如果直接从详情页访问）
+	var item = new Zotero.Item("newspaperArticle");
+
+	var titleEl = doc.querySelector('.art-topic') || doc.querySelector('.newsTitle');
+	if (titleEl) {
+		item.title = titleEl.textContent.trim();
+	}
+
+	// 尝试从 URL 参数获取信息
+	var urlParams = new URLSearchParams(url.split('?')[1]);
+	if (urlParams.get('paperName')) {
+		item.publicationTitle = decodeURIComponent(urlParams.get('paperName'));
+	}
+	if (urlParams.get('pubDate')) {
+		item.date = urlParams.get('pubDate');
+	}
+
+	item.url = url;
+	item.language = "zh-CN";
+	item.libraryCatalog = "中国历史文献总库·近代报纸数据库";
+
+	item.attachments.push({
+		title: "Newspaper Database Record",
+		url: url,
+		mimeType: "text/html",
+		snapshot: false
+	});
+
+	item.complete();
+}
+
+
+/** BEGIN TEST CASES **/
+var testCases = [
+];
+/** END TEST CASES **/

--- a/China National Library - Modern Newspaper Database.js
+++ b/China National Library - Modern Newspaper Database.js
@@ -1,21 +1,21 @@
 {
-	"translatorID": "b2c3d4e5-f6a7-8901-bcde-f12345678901",
+	"translatorID": "89705062-43de-4566-b1cd-eb98f69b5053",
 	"label": "China National Library - Modern Newspaper Database",
-	"creator": "Zotero User",
-	"target": "^https?://bz-nlcpress-com-s-[0-9]+\\.ycfw\\.library\\.hb\\.cn:[0-9]+/library/publish/default/(PaperSearch|ChengpinHistoryDetail_pic|paperLayoutView_pic|PaperAll)\\.jsp\\?.*",
-	"minVersion": "3.0",
+	"creator": "Daxoel",
+	"target": "^https?://bz-nlcpress-com-s-[0-9]+\.ycfw\.library\.hb\.cn:[0-9]+/library/publish/default/(PaperSearch|ChengpinHistoryDetail_pic|paperLayoutView_pic|PaperAll)\.jsp\?.*",
+	"minVersion": "5.0",
 	"maxVersion": "",
 	"priority": 100,
 	"inRepository": true,
 	"translatorType": 4,
 	"browserSupport": "gcsibv",
-	"lastUpdated": "2026-07-10 19:45:00"
+	"lastUpdated": "2026-08-18 10:00:00"
 }
 
 /*
 	***** BEGIN LICENSE BLOCK *****
 
-	Copyright © 2026 Zotero User
+	Copyright © 2026 4965898
 
 	This file is part of Zotero.
 
@@ -46,16 +46,15 @@ function detectWeb(doc, url) {
 	return false;
 }
 
-
 function getSearchResults(doc, checkOnly) {
-	var items = {};
-	var found = false;
-	var rows = doc.querySelectorAll('.newsList02');
-	for (var i = 0; i < rows.length; i++) {
-		var titleLink = rows[i].querySelector('.newsTitle .art-topic');
+	const items = {};
+	let found = false;
+	const rows = doc.querySelectorAll('.newsList02');
+	for (const row of rows) {
+		const titleLink = row.querySelector('.newsTitle .art-topic');
 		if (!titleLink) continue;
-		var title = titleLink.textContent.trim();
-		var docID = rows[i].getAttribute('docid');
+		const title = titleLink.textContent.trim();
+		const docID = row.getAttribute('docid');
 		if (!title || !docID) continue;
 		if (checkOnly) return true;
 		found = true;
@@ -64,37 +63,34 @@ function getSearchResults(doc, checkOnly) {
 	return found ? items : false;
 }
 
-
-function doWeb(doc, url) {
-	if (detectWeb(doc, url) == "multiple") {
-		Zotero.selectItems(getSearchResults(doc, false), function (items) {
-			if (!items) return;
-			for (var docID in items) {
-				scrapeItemFromSearchResult(doc, docID, url);
-			}
-		});
+async function doWeb(doc, url) {
+	if (detectWeb(doc, url) === "multiple") {
+		const items = await Z.selectItems(getSearchResults(doc, false));
+		if (!items) return;
+		for (const docID in items) {
+			scrapeItemFromSearchResult(doc, docID, url);
+		}
 	}
 	else {
 		scrape(doc, url);
 	}
 }
 
-
 function scrapeItemFromSearchResult(doc, docID, url) {
-	var row = doc.querySelector('.newsList02[docid="' + docID + '"]');
+	const row = doc.querySelector('.newsList02[docid="' + docID + '"]');
 	if (!row) return;
 
-	var item = new Zotero.Item("newspaperArticle");
+	const item = new Z.Item("newspaperArticle");
 
 	// 标题
-	var titleEl = row.querySelector('.newsTitle .art-topic');
+	const titleEl = row.querySelector('.newsTitle .art-topic');
 	if (titleEl) {
 		item.title = titleEl.textContent.trim();
 	}
 
 	// 链接
-	var links = row.querySelectorAll('li.newsStyle.right a');
-	var baseURL = url.match(/^(https?:\/\/[^\/]+\/library\/publish\/default\/)/);
+	const links = row.querySelectorAll('li.newsStyle.right a');
+	let baseURL = url.match(/^(https?:\/\/[^\/]+\/library\/publish\/default\/)/);
 	baseURL = baseURL ? baseURL[1] : "";
 
 	// 报纸名
@@ -124,21 +120,21 @@ function scrapeItemFromSearchResult(doc, docID, url) {
 	item.libraryCatalog = "中国历史文献总库·近代报纸数据库";
 
 	// PDF 附件
-	var downloadLink = null;
-	var allLinks = row.querySelectorAll('a');
-	for (var i = 0; i < allLinks.length; i++) {
-		var onclickAttr = allLinks[i].getAttribute('onclick');
+	let downloadLink = null;
+	const allLinks = row.querySelectorAll('a');
+	for (const link of allLinks) {
+		const onclickAttr = link.getAttribute('onclick');
 		if (onclickAttr && onclickAttr.indexOf('downloadPaper') !== -1) {
-			downloadLink = allLinks[i];
+			downloadLink = link;
 			break;
 		}
 	}
 	if (downloadLink && baseURL) {
-		var onclickAttr = downloadLink.getAttribute('onclick');
+		const onclickAttr = downloadLink.getAttribute('onclick');
 		if (onclickAttr) {
-			var match = onclickAttr.match(/downloadPaper\('([^']+)'\)/);
+			const match = onclickAttr.match(/downloadPaper\('([^']+)'\)/);
 			if (match) {
-				var pdfURL = baseURL + match[1];
+				const pdfURL = baseURL + match[1];
 				item.attachments.push({
 					title: "Full Text PDF",
 					url: pdfURL,
@@ -151,18 +147,17 @@ function scrapeItemFromSearchResult(doc, docID, url) {
 	item.complete();
 }
 
-
 function scrape(doc, url) {
 	// 详情页抓取逻辑（如果直接从详情页访问）
-	var item = new Zotero.Item("newspaperArticle");
+	const item = new Z.Item("newspaperArticle");
 
-	var titleEl = doc.querySelector('.art-topic') || doc.querySelector('.newsTitle');
+	const titleEl = doc.querySelector('.art-topic') || doc.querySelector('.newsTitle');
 	if (titleEl) {
 		item.title = titleEl.textContent.trim();
 	}
 
 	// 尝试从 URL 参数获取信息
-	var urlParams = new URLSearchParams(url.split('?')[1]);
+	const urlParams = new URLSearchParams(url.split('?')[1]);
 	if (urlParams.get('paperName')) {
 		item.publicationTitle = decodeURIComponent(urlParams.get('paperName'));
 	}

--- a/China National Library - Modern Newspaper Database.js
+++ b/China National Library - Modern Newspaper Database.js
@@ -148,13 +148,6 @@ function scrapeItemFromSearchResult(doc, docID, url) {
 		}
 	}
 
-	item.attachments.push({
-		title: "Newspaper Database Record",
-		url: item.url,
-		mimeType: "text/html",
-		snapshot: false
-	});
-
 	item.complete();
 }
 
@@ -180,13 +173,6 @@ function scrape(doc, url) {
 	item.url = url;
 	item.language = "zh-CN";
 	item.libraryCatalog = "中国历史文献总库·近代报纸数据库";
-
-	item.attachments.push({
-		title: "Newspaper Database Record",
-		url: url,
-		mimeType: "text/html",
-		snapshot: false
-	});
 
 	item.complete();
 }

--- a/China National Library - Republic Era.js
+++ b/China National Library - Republic Era.js
@@ -1,0 +1,164 @@
+{
+	"translatorID": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+	"label": "China National Library - Republic Era",
+	"creator": "Zotero User",
+	"target": "^https?://read\\.nlc\\.cn/allSearch/(searchDetail|searchList)\\?.*",
+	"minVersion": "3.0",
+	"maxVersion": "",
+	"priority": 100,
+	"inRepository": true,
+	"translatorType": 4,
+	"browserSupport": "gcsibv",
+	"lastUpdated": "2026-07-10 17:15:00"
+}
+
+/*
+	***** BEGIN LICENSE BLOCK *****
+
+	Copyright © 2026 Zotero User
+
+	This file is part of Zotero.
+
+	Zotero is free software: you can redistribute it and/or modify
+	it under the terms of the GNU Affero General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	Zotero is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+	GNU Affero General Public License for more details.
+
+	You should have received a copy of the GNU Affero General Public License
+	along with Zotero. If not, see <http://www.gnu.org/licenses/>.
+
+	***** END LICENSE BLOCK *****
+*/
+
+
+function detectWeb(doc, url) {
+	if (url.includes("/allSearch/searchDetail?") && (doc.querySelector('div.title') || doc.querySelector('input#title'))) {
+		return "book";
+	}
+	if (url.includes("/allSearch/searchList?") && getSearchResults(doc, true)) {
+		return "multiple";
+	}
+	return false;
+}
+
+
+function getSearchResults(doc, checkOnly) {
+	var items = {};
+	var found = false;
+	var rows = doc.querySelectorAll('ul.YMH2019_New_MGZYK_List1.List-TB > li');
+	for (var i = 0; i < rows.length; i++) {
+		var a = rows[i].querySelector('a');
+		if (!a) continue;
+		var href = a.href;
+		var title = text(rows[i], 'span.tt');
+		if (!href || !title) continue;
+		if (checkOnly) return true;
+		found = true;
+		items[href] = title.trim();
+	}
+	return found ? items : false;
+}
+
+
+function doWeb(doc, url) {
+	if (detectWeb(doc, url) == "multiple") {
+		Zotero.selectItems(getSearchResults(doc, false), function (items) {
+			if (!items) return;
+			ZU.processDocuments(Object.keys(items), scrape);
+		});
+	}
+	else {
+		scrape(doc, url);
+	}
+}
+
+
+function scrape(doc, url) {
+	var item = new Zotero.Item("book");
+
+	item.title = (text(doc, 'div.title') || text(doc, 'input#title')).trim();
+
+	var author = text(doc, 'input#author') || getFieldValue(doc, '责任者');
+	if (author) {
+		author = author.replace(/[著编译辑撰]+$/, '').trim();
+		var authors = author.split(/[,，]/);
+		for (var i = 0; i < authors.length; i++) {
+			var name = authors[i].trim();
+			if (name) {
+				item.creators.push({
+					lastName: name,
+					creatorType: "author",
+					fieldMode: 1
+				});
+			}
+		}
+	}
+
+	var publisher = getFieldValue(doc, '出版者');
+	if (publisher) {
+		item.publisher = publisher.trim();
+	}
+
+	var date = getFieldValue(doc, '出版时间');
+	if (date) {
+		item.date = date.trim();
+	}
+
+	var subject = getFieldValue(doc, '主题') || text(doc, 'input#Keyword');
+	if (subject) {
+		item.tags = subject.split(/[;；,，]/).map(function (t) { return t.trim(); }).filter(function (t) { return t; });
+	}
+
+	var physicalDesc = getFieldValue(doc, '载体形态');
+	if (physicalDesc) {
+		item.numPages = physicalDesc.trim();
+	}
+
+	var abstract = getFieldValue(doc, '摘要');
+	if (abstract) {
+		item.abstractNote = abstract.trim();
+	}
+
+	var identifier = text(doc, 'input#identifier');
+	if (identifier) {
+		item.callNumber = identifier.trim();
+	}
+
+	item.url = url;
+	item.language = "zh-CN";
+
+	item.attachments.push({
+		title: "China National Library Record",
+		url: url,
+		mimeType: "text/html",
+		snapshot: false
+	});
+
+	item.complete();
+}
+
+
+function getFieldValue(doc, fieldName) {
+	var labels = doc.querySelectorAll('.XiangXi label');
+	for (var i = 0; i < labels.length; i++) {
+		var textContent = labels[i].textContent.trim();
+		if (textContent.startsWith(fieldName + '：') || textContent.startsWith(fieldName + ':')) {
+			var valueSpan = labels[i].querySelector('span.t1');
+			if (valueSpan) {
+				return valueSpan.textContent.trim();
+			}
+		}
+	}
+	return null;
+}
+
+
+/** BEGIN TEST CASES **/
+var testCases = [
+];
+/** END TEST CASES **/

--- a/China National Library - Republic Era.js
+++ b/China National Library - Republic Era.js
@@ -1,21 +1,21 @@
 {
-	"translatorID": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+	"translatorID": "44cfd2f1-114f-48d0-b62c-f4d405ac5fb7",
 	"label": "China National Library - Republic Era",
-	"creator": "Zotero User",
-	"target": "^https?://read\\.nlc\\.cn/allSearch/(searchDetail|searchList)\\?.*",
-	"minVersion": "3.0",
+	"creator": "Daxoel",
+	"target": "^https?://read\.nlc\.cn/allSearch/(searchDetail|searchList)\?.*",
+	"minVersion": "5.0",
 	"maxVersion": "",
 	"priority": 100,
 	"inRepository": true,
 	"translatorType": 4,
 	"browserSupport": "gcsibv",
-	"lastUpdated": "2026-07-10 17:15:00"
+	"lastUpdated": "2026-08-18 10:00:00"
 }
 
 /*
 	***** BEGIN LICENSE BLOCK *****
 
-	Copyright © 2026 Zotero User
+	Copyright © 2026 4965898
 
 	This file is part of Zotero.
 
@@ -46,16 +46,15 @@ function detectWeb(doc, url) {
 	return false;
 }
 
-
 function getSearchResults(doc, checkOnly) {
-	var items = {};
-	var found = false;
-	var rows = doc.querySelectorAll('ul.YMH2019_New_MGZYK_List1.List-TB > li');
-	for (var i = 0; i < rows.length; i++) {
-		var a = rows[i].querySelector('a');
+	const items = {};
+	let found = false;
+	const rows = doc.querySelectorAll('ul.YMH2019_New_MGZYK_List1.List-TB > li');
+	for (const row of rows) {
+		const a = row.querySelector('a');
 		if (!a) continue;
-		var href = a.href;
-		var title = text(rows[i], 'span.tt');
+		const href = a.href;
+		const title = text(row, 'span.tt');
 		if (!href || !title) continue;
 		if (checkOnly) return true;
 		found = true;
@@ -64,34 +63,31 @@ function getSearchResults(doc, checkOnly) {
 	return found ? items : false;
 }
 
-
-function doWeb(doc, url) {
-	if (detectWeb(doc, url) == "multiple") {
-		Zotero.selectItems(getSearchResults(doc, false), function (items) {
-			if (!items) return;
-			ZU.processDocuments(Object.keys(items), scrape);
-		});
+async function doWeb(doc, url) {
+	if (detectWeb(doc, url) === "multiple") {
+		const items = await Z.selectItems(getSearchResults(doc, false));
+		if (!items) return;
+		await processDocuments(Object.keys(items), scrape);
 	}
 	else {
 		scrape(doc, url);
 	}
 }
 
-
 function scrape(doc, url) {
-	var item = new Zotero.Item("book");
+	const item = new Z.Item("book");
 
 	item.title = (text(doc, 'div.title') || text(doc, 'input#title')).trim();
 
-	var author = text(doc, 'input#author') || getFieldValue(doc, '责任者');
+	const author = text(doc, 'input#author') || getFieldValue(doc, '责任者');
 	if (author) {
-		author = author.replace(/[著编译辑撰]+$/, '').trim();
-		var authors = author.split(/[,，]/);
-		for (var i = 0; i < authors.length; i++) {
-			var name = authors[i].trim();
-			if (name) {
+		const cleanAuthor = author.replace(/[著编译辑撰]+$/, '').trim();
+		const authors = cleanAuthor.split(/[,，]/);
+		for (const name of authors) {
+			const trimmedName = name.trim();
+			if (trimmedName) {
 				item.creators.push({
-					lastName: name,
+					lastName: trimmedName,
 					creatorType: "author",
 					fieldMode: 1
 				});
@@ -99,32 +95,32 @@ function scrape(doc, url) {
 		}
 	}
 
-	var publisher = getFieldValue(doc, '出版者');
+	const publisher = getFieldValue(doc, '出版者');
 	if (publisher) {
 		item.publisher = publisher.trim();
 	}
 
-	var date = getFieldValue(doc, '出版时间');
+	const date = getFieldValue(doc, '出版时间');
 	if (date) {
 		item.date = date.trim();
 	}
 
-	var subject = getFieldValue(doc, '主题') || text(doc, 'input#Keyword');
+	const subject = getFieldValue(doc, '主题') || text(doc, 'input#Keyword');
 	if (subject) {
 		item.tags = subject.split(/[;；,，]/).map(function (t) { return t.trim(); }).filter(function (t) { return t; });
 	}
 
-	var physicalDesc = getFieldValue(doc, '载体形态');
+	const physicalDesc = getFieldValue(doc, '载体形态');
 	if (physicalDesc) {
 		item.numPages = physicalDesc.trim();
 	}
 
-	var abstract = getFieldValue(doc, '摘要');
+	const abstract = getFieldValue(doc, '摘要');
 	if (abstract) {
 		item.abstractNote = abstract.trim();
 	}
 
-	var identifier = text(doc, 'input#identifier');
+	const identifier = text(doc, 'input#identifier');
 	if (identifier) {
 		item.callNumber = identifier.trim();
 	}
@@ -135,13 +131,12 @@ function scrape(doc, url) {
 	item.complete();
 }
 
-
 function getFieldValue(doc, fieldName) {
-	var labels = doc.querySelectorAll('.XiangXi label');
-	for (var i = 0; i < labels.length; i++) {
-		var textContent = labels[i].textContent.trim();
+	const labels = doc.querySelectorAll('.XiangXi label');
+	for (const label of labels) {
+		const textContent = label.textContent.trim();
 		if (textContent.startsWith(fieldName + '：') || textContent.startsWith(fieldName + ':')) {
-			var valueSpan = labels[i].querySelector('span.t1');
+			const valueSpan = label.querySelector('span.t1');
 			if (valueSpan) {
 				return valueSpan.textContent.trim();
 			}
@@ -149,7 +144,6 @@ function getFieldValue(doc, fieldName) {
 	}
 	return null;
 }
-
 
 /** BEGIN TEST CASES **/
 var testCases = [

--- a/China National Library - Republic Era.js
+++ b/China National Library - Republic Era.js
@@ -132,13 +132,6 @@ function scrape(doc, url) {
 	item.url = url;
 	item.language = "zh-CN";
 
-	item.attachments.push({
-		title: "China National Library Record",
-		url: url,
-		mimeType: "text/html",
-		snapshot: false
-	});
-
 	item.complete();
 }
 

--- a/README.md
+++ b/README.md
@@ -40,3 +40,22 @@
 ## 🎈问题交流
 
 如果有问题的，可以加QQ群 913637964，一起交流。
+
+---
+
+## 📚 本仓库新增翻译器（@Daxoel）
+
+以下翻译器由 [@Daxoel](https://github.com/4965898) 开发并维护，均已按 Zotero 现代规范编写（使用 `const`/`let`、现代 Promise API，不使用已废弃的 FW 框架与 `ZU.processDocuments` 等旧 API）。
+
+| 翻译器 | 抓取网站 | 说明 |
+|--------|---------|------|
+| [CADAL.js](./CADAL.js) | [CADAL 大学数字图书馆](https://cadal.edu.cn) | 抓取图书/学位论文/标准/期刊/会议/专利详情页与搜索结果，支持多类型条目 |
+| [CNBKSY V2.js](./CNBKSY%20V2.js) | [中国近代报刊数据库 V2](https://www.cnbksy.com/v2) | 抓取期刊文章/报纸文章详情页与搜索结果，支持 PDF 附件 |
+| [China National Library - Republic Era.js](./China%20National%20Library%20-%20Republic%20Era.js) | [国家图书馆民国文献](https://read.nlc.cn) | 抓取民国图书详情页与搜索结果，中文作者单字段保存 |
+| [China National Library - Modern Newspaper Database.js](./China%20National%20Library%20-%20Modern%20Newspaper%20Database.js) | [中国历史文献总库·近代报纸数据库](https://bz-nlcpress-com-s-*.ycfw.library.hb.cn) | 抓取近代报纸篇目与报纸信息，支持 PDF 附件 |
+| [ShuKui.js](./ShuKui.js) | [书葵网](https://www.shukui.net) | 抓取图书详情页与搜索结果，支持封面图片与 MD5/文件大小信息 |
+| [Wikimedia Commons.js](./Wikimedia%20Commons.js) | [Wikimedia Commons](https://commons.wikimedia.org) | 解析图书文件页（`{{Book}}`/`{{Information}}` 模板）与搜索/画廊，支持 PDF/DjVu 附件；特别支持超星爬取的中文民国书籍与古籍 |
+
+### 更新日志
+
+详见 [CHANGELOG.md](./CHANGELOG.md)。

--- a/Shanghai International Studies University Library.js
+++ b/Shanghai International Studies University Library.js
@@ -1,0 +1,545 @@
+{
+	"translatorID": "c9d2e8f4-3b1a-4c5d-9e6f-7a8b9c0d1e2f",
+	"label": "Shanghai International Studies University Library",
+	"creator": "Zotero User",
+	"target": "^https?://findshisu\\.libsp\\.cn",
+	"minVersion": "5.0",
+	"maxVersion": "",
+	"priority": 100,
+	"inRepository": true,
+	"translatorType": 4,
+	"browserSupport": "gcsibv",
+	"lastUpdated": "2026-07-12 13:00:00"
+}
+
+/*
+	***** BEGIN LICENSE BLOCK *****
+
+	Copyright © 2026 Zotero User
+
+	This file is part of Zotero.
+
+	Zotero is free software: you can redistribute it and/or modify
+	it under the terms of the GNU Affero General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	Zotero is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+	GNU Affero General Public License for more details.
+
+	You should have received a copy of the GNU Affero General Public License
+	along with Zotero. If not, see <http://www.gnu.org/licenses/>.
+
+	***** END LICENSE BLOCK *****
+*/
+
+function detectWeb(doc, url) {
+	// SPA: monitor body for React rendering before content appears
+	var root = doc.querySelector('#app, #root, .ant-app, body');
+	if (root) {
+		Z.monitorDOMChanges(root, { childList: true, subtree: true });
+	}
+
+	if (/bookDetails/.test(url) && hasFields(doc)) {
+		return detectType(doc);
+	}
+	if (/searchList/.test(url) && !/bookDetails/.test(url) && getSearchResults(doc, true)) {
+		return 'multiple';
+	}
+	return false;
+}
+
+function hasFields(doc) {
+	if (doc.querySelector('.col, .marcRight, .marcLeft')) return true;
+	// Check for p > span with 【label】 structure (standard doc pages)
+	var pEls = doc.querySelectorAll('p');
+	for (var i = 0; i < pEls.length; i++) {
+		var spans = pEls[i].querySelectorAll('span');
+		for (var j = 0; j < spans.length; j++) {
+			var t = ZU.trimInternal(spans[j].textContent);
+			if (/^【.+?】$/.test(t)) return true;
+		}
+	}
+	return false;
+}
+
+function getSearchResults(doc, checkOnly) {
+	var items = {};
+	var found = false;
+	var rows = doc.querySelectorAll('.ant-list-item');
+	for (var i = 0; i < rows.length; i++) {
+		var a = rows[i].querySelector('[class*="infotit"]');
+		if (!a) continue;
+		var href = a.href;
+		if (!href) continue;
+		// Clean title: remove number prefix "1. " and type indicator "[图书] "
+		var title = ZU.trimInternal(a.textContent)
+			.replace(/^\d+\.\s*/, '')
+			.replace(/^\[.+?\]\s*/, '');
+		if (!title) continue;
+		if (checkOnly) return true;
+		found = true;
+		items[href] = title;
+	}
+	return found ? items : false;
+}
+
+function doWeb(doc, url) {
+	if (detectWeb(doc, url) === 'multiple') {
+		var searchResults = getSearchResults(doc, false);
+		Zotero.selectItems(searchResults, function (items) {
+			if (!items) return;
+			// SPA: processDocuments can't render hash-routed pages
+			// Scrape directly from search results page
+			for (var itemUrl in items) {
+				scrapeFromSearch(doc, itemUrl, items[itemUrl]);
+			}
+		});
+	}
+	else {
+		scrape(doc, url);
+	}
+}
+
+function scrapeFromSearch(doc, url, fallbackTitle) {
+	// Find the corresponding search result item
+	var row = null;
+	var rows = doc.querySelectorAll('.ant-list-item');
+	for (var i = 0; i < rows.length; i++) {
+		var a = rows[i].querySelector('[class*="infotit"]');
+		if (a && a.href === url) {
+			row = rows[i];
+			break;
+		}
+	}
+	if (!row) {
+		// Fallback: create minimal item
+		var fallback = new Zotero.Item('book');
+		fallback.url = url;
+		fallback.title = fallbackTitle || 'Untitled';
+		fallback.libraryCatalog = '上海外国语大学图书馆';
+		fallback.language = 'zh-CN';
+		fallback.complete();
+		return;
+	}
+
+	// Determine item type from [图书] or [学位论文] in title text
+	var titleLink = row.querySelector('[class*="infotit"]');
+	var rawTitle = titleLink ? ZU.trimInternal(titleLink.textContent) : '';
+	var typeMatch = rawTitle.match(/\[(.+?)\]/);
+	var itemType = 'book';
+	if (typeMatch) {
+		if (/学位论文/.test(typeMatch[1])) itemType = 'thesis';
+		else if (/标准/.test(typeMatch[1])) itemType = 'standard';
+	}
+
+	var item = new Zotero.Item(itemType);
+	item.url = url;
+	item.libraryCatalog = '上海外国语大学图书馆';
+	item.language = 'zh-CN';
+
+	// Title: remove number prefix and [type] indicator
+	item.title = rawTitle.replace(/^\d+\.\s*/, '').replace(/^\[.+?\]\s*/, '') || fallbackTitle || 'Untitled';
+
+	// Metadata from .modeInfo spans - determine type by content, not position
+	var extraParts = [];
+	var modeInfos = row.querySelectorAll('[class*="easymode"] [class*="modeInfo"]');
+	for (var j = 0; j < modeInfos.length; j++) {
+		var span = modeInfos[j].querySelector('span[title]');
+		if (!span) continue;
+		var titleAttr = span.getAttribute('title') || '';
+		var innerSpans = span.querySelectorAll('span');
+
+		if (innerSpans.length >= 2) {
+			// Publisher/Date/ISBN from inner spans
+			item.publisher = innerSpans[0].textContent.trim();
+			item.date = innerSpans[1].textContent.trim();
+			if (innerSpans.length >= 3) {
+				var isbn = innerSpans[2].textContent.trim();
+				if (/[\dXx-]{10,}/.test(isbn)) item.ISBN = isbn;
+			}
+		}
+		else if (titleAttr && /[A-Za-z]/.test(titleAttr) && /\//.test(titleAttr)) {
+			// CLC: alphanumeric with / (e.g. "H059/F9", "H059-092/Q1")
+			extraParts.push('CLC: ' + titleAttr);
+		}
+		else if (titleAttr && /、/.test(titleAttr) && titleAttr.length > 5) {
+			// Subject classification (e.g. "语言、文字-写作学与修辞学")
+			extraParts.push('Subject: ' + titleAttr);
+		}
+		else if (titleAttr) {
+			// Author (e.g. "顾忆青", "傅敬民等著", "王宏志主编")
+			addCreators(item, titleAttr);
+		}
+	}
+	if (extraParts.length > 0) {
+		item.extra = extraParts.join('\n');
+	}
+
+	// Abstract
+	var abstractEl = row.querySelector('[class*="adstract"]');
+	if (abstractEl) {
+		item.abstractNote = abstractEl.getAttribute('title') || ZU.trimInternal(abstractEl.textContent);
+	}
+
+	if (itemType === 'thesis') {
+		item.thesisType = '学位论文';
+	}
+
+	item.attachments.push({
+		title: '上海外国语大学图书馆 Snapshot',
+		url: url,
+		mimeType: 'text/html',
+		snapshot: false
+	});
+	item.complete();
+}
+
+function scrape(doc, url) {
+	var itemType = detectType(doc);
+	var item = new Zotero.Item(itemType);
+
+	item.url = url;
+	item.libraryCatalog = '上海外国语大学图书馆';
+	item.language = 'zh-CN';
+
+	var fields = getDetailFields(doc);
+
+	// Title: prefer doc.title (clean title without author), fallback to field
+	var rawTitleField = getField(fields, ['题名', '正题名']);
+	if (doc.title) {
+		item.title = doc.title.trim();
+	}
+	else if (rawTitleField) {
+		// Split "title.author著" or "title:author" -> title only
+		var titleMatch = rawTitleField.match(/^([\s\S]+)[\.：:]([\u4e00-\u9fa5]{1,}[著编译辑撰注]*)$/);
+		item.title = titleMatch ? titleMatch[1].trim() : rawTitleField.trim();
+	}
+
+	// Author: try "个人责任者" field first, fallback to extracting from "题名/责任者"
+	var author = getField(fields, ['个人责任者', '作者']);
+	if (!author && rawTitleField) {
+		// Extract author after last separator: "title:作者" or "title.作者著"
+		var authorMatch = rawTitleField.match(/[:：.．]\s*([^:：.．]+)$/);
+		if (authorMatch) {
+			author = authorMatch[1].trim();
+		}
+	}
+	addCreators(item, author);
+
+	var publisher = getField(fields, ['出版发行', '出版者', '出版社']);
+	if (publisher) {
+		// "北京:中国社会科学出版社,2024" -> place:publisher,date
+		var pubMatch = publisher.match(/^(.+?)[：:]\s*(.+?)[,，;；]\s*(\d{4}[\s\S]*)$/);
+		if (pubMatch) {
+			item.place = pubMatch[1].trim();
+			item.publisher = pubMatch[2].trim();
+			item.date = pubMatch[3].trim();
+		}
+		else {
+			// No place prefix, try publisher,date only
+			var m = publisher.match(/^(.+?)[,，;；]\s*(\d{4}[\s\S]*)$/);
+			if (m) {
+				item.publisher = m[1].trim();
+				item.date = m[2].trim();
+			}
+			else if (/^\d{4}[-\/.]\d{1,2}[-\/.]\d{1,2}/.test(publisher.trim()) || /^\d{4}$/.test(publisher.trim())) {
+				// It's just a date (e.g. "2015-03-01" or "2024"), not a publisher
+				item.date = publisher.trim();
+			}
+			else {
+				item.publisher = publisher;
+			}
+		}
+	}
+
+	var date = getField(fields, ['出版日期', '出版年', '年份', '日期']);
+	if (date) item.date = date;
+
+	var isbn = getField(fields, ['ISBN']);
+	if (isbn) {
+		var isbnMatch = isbn.match(/([\dXx-]{10,})/);
+		if (isbnMatch) item.ISBN = isbnMatch[1];
+	}
+
+	var physical = getField(fields, ['载体形态', '页数', '总页数']);
+	if (physical) {
+		var pageMatch = physical.match(/(\d+)\s*[页pP]/);
+		if (pageMatch) item.numPages = pageMatch[1];
+	}
+
+	var abstract = getField(fields, ['提要', '摘要', '文摘', '内容提要']);
+	if (abstract) item.abstractNote = abstract;
+
+	var subject = getField(fields, ['学科主题', '主题', '关键词', '非控制主题词']);
+	if (subject) {
+		item.tags = subject.split(/[,，;；]/).map(function (t) { return t.trim(); }).filter(function (t) { return t; });
+	}
+
+	var clc = getField(fields, ['中图法分类号', '分类号']);
+	if (clc) item.extra = addExtra('CLC', clc);
+
+	if (itemType === 'thesis') {
+		var degree = getField(fields, ['学位']);
+		item.thesisType = (degree ? degree + '学位' : '学位') + '论文';
+		var univ = getField(fields, ['学位授予单位', '授予单位', '授予机构', '培养单位', '学校']);
+		// Skip if value looks like a date (false match from 出版发行项)
+		if (univ && !/^\d{4}[-\/.]/.test(univ.trim())) {
+			item.university = univ;
+		}
+	}
+	else if (itemType === 'standard') {
+		item.number = getField(fields, ['标准号', '标准编号']);
+		item.organization = getField(fields, ['发布机构', '团体责任者', '团体次要责任者']);
+	}
+
+	item.attachments.push({
+		title: '上海外国语大学图书馆 Snapshot',
+		url: url,
+		mimeType: 'text/html',
+		snapshot: false
+	});
+
+	item.complete();
+}
+
+function detectType(doc) {
+	// Search all elements for type indicator 【学位论文】 etc.
+	// Check title element first (e.g. div.title___3zGxP contains 【学位论文】title)
+	var titleEl = doc.querySelector('[class*="title"]');
+	if (titleEl) {
+		var titleText = titleEl.textContent;
+		if (/【学位论文】/.test(titleText)) return 'thesis';
+		if (/【规范文档】/.test(titleText)) return 'book';
+		if (/【标准】/.test(titleText)) return 'standard';
+		if (/【期刊/.test(titleText)) return 'journalArticle';
+		if (/【会议/.test(titleText)) return 'conferencePaper';
+		if (/【专利】/.test(titleText)) return 'patent';
+	}
+	// Broad search: check all elements for type indicators (no length limit)
+	var allEls = doc.querySelectorAll('div, span, p, label, h1, h2, h3, h4, a');
+	for (var i = 0; i < allEls.length; i++) {
+		var t = allEls[i].textContent;
+		if (/【学位论文】/.test(t)) return 'thesis';
+		if (/【规范文档】/.test(t)) return 'book';
+		if (/【标准】/.test(t)) return 'standard';
+		if (/【期刊/.test(t)) return 'journalArticle';
+		if (/【会议/.test(t)) return 'conferencePaper';
+		if (/【专利】/.test(t)) return 'patent';
+	}
+	return 'book';
+}
+
+function getDetailFields(doc) {
+	var fields = {};
+
+	// Strategy 1: .col > .marcLeft + .marcRight (book/thesis pages)
+	var rows = doc.querySelectorAll('.col');
+	for (var i = 0; i < rows.length; i++) {
+		var labelEl = rows[i].querySelector('.marcLeft');
+		var valueEl = rows[i].querySelector('.marcRight');
+		if (!labelEl || !valueEl) continue;
+		var label = ZU.trimInternal(labelEl.textContent).replace(/[【】]/g, '');
+		if (label) fields[label] = valueEl;
+	}
+	if (Object.keys(fields).length > 0) return fields;
+
+	// Strategy 2: p > span (label) + span.content___* (value) (standard doc pages)
+	var pRows = doc.querySelectorAll('p');
+	for (var j = 0; j < pRows.length; j++) {
+		var spans = pRows[j].querySelectorAll(':scope > span');
+		var labelSpan = null;
+		var valueSpan = null;
+		for (var k = 0; k < spans.length; k++) {
+			var spanText = ZU.trimInternal(spans[k].textContent);
+			if (/^【.+?】$/.test(spanText)) {
+				labelSpan = spans[k];
+			}
+			else if (spans[k].className && /content/.test(spans[k].className)) {
+				valueSpan = spans[k];
+			}
+		}
+		if (labelSpan && valueSpan) {
+			var fieldLabel = ZU.trimInternal(labelSpan.textContent).replace(/[【】]/g, '');
+			if (fieldLabel) fields[fieldLabel] = valueSpan;
+		}
+	}
+	if (Object.keys(fields).length > 0) return fields;
+
+	// Strategy 3: find span elements with 【label】 text, get next sibling span
+	var spanEls = doc.querySelectorAll('span');
+	for (var m = 0; m < spanEls.length; m++) {
+		var spanText3 = ZU.trimInternal(spanEls[m].textContent);
+		var match = spanText3.match(/^【(.+?)】$/);
+		if (match) {
+			var fieldLabel3 = match[1];
+			var nextSpan = spanEls[m].nextElementSibling;
+			if (nextSpan && nextSpan.textContent.trim()) {
+				fields[fieldLabel3] = nextSpan;
+			}
+		}
+	}
+
+	return fields;
+}
+
+function getField(fields, labels) {
+	if (!Array.isArray(labels)) labels = [labels];
+	// Pass 1: exact match (avoid "责任者" matching "题名/责任者")
+	for (var i = 0; i < labels.length; i++) {
+		for (var key in fields) {
+			if (key === labels[i]) return ZU.trimInternal(fields[key].textContent);
+		}
+	}
+	// Pass 2: partial match
+	for (var j = 0; j < labels.length; j++) {
+		var re = new RegExp(labels[j], 'i');
+		for (var key2 in fields) {
+			if (re.test(key2)) return ZU.trimInternal(fields[key2].textContent);
+		}
+	}
+	return '';
+}
+
+function addCreators(item, authorString) {
+	if (!authorString) return;
+	authorString = authorString.replace(/[著编译辑撰注校订整理主编]+$/, '').trim();
+	// Remove nationality prefix like (澳)
+	authorString = authorString.replace(/^\([\u4e00-\u9fa5]{1,3}\)\s*/, '');
+
+	// Split by commas/semicolons, but not inside parentheses
+	var names = authorString.split(/[,，;；](?![^(]*\))/);
+
+	// Merge Chinese name + immediately following Western parenthetical
+	// e.g. ["皮姆", "(Pym,Anthony)"] → ["皮姆(Pym,Anthony)"]
+	var mergedNames = [];
+	for (var i = 0; i < names.length; i++) {
+		var n = names[i].trim();
+		if (!n) continue;
+		if (mergedNames.length > 0 && /^\([A-Za-z]/.test(n) && /[\u4e00-\u9fa5]/.test(mergedNames[mergedNames.length - 1])) {
+			mergedNames[mergedNames.length - 1] += n;
+		}
+		else {
+			mergedNames.push(n);
+		}
+	}
+
+	for (var j = 0; j < mergedNames.length; j++) {
+		var name = mergedNames[j].trim();
+		if (!name) continue;
+
+		// Check for Western name in parentheses: 皮姆(Pym,Anthony) or (Pym,Anthony)
+		var westernMatch = name.match(/\(([A-Za-z][^)]+)\)/);
+		if (westernMatch) {
+			var creator = ZU.cleanAuthor(westernMatch[1], 'author');
+			if (creator.lastName) {
+				item.creators.push(creator);
+				continue;
+			}
+		}
+
+		// Remove any parenthetical content for Chinese name
+		name = name.replace(/\([^)]*\)/g, '').trim();
+		if (!name) continue;
+
+		if (/[\u4e00-\u9fa5]/.test(name)) {
+			item.creators.push({
+				lastName: name,
+				creatorType: 'author',
+				fieldMode: 1
+			});
+		}
+		else {
+			var creator2 = ZU.cleanAuthor(name, 'author');
+			if (creator2.lastName) {
+				item.creators.push(creator2);
+			}
+		}
+	}
+}
+
+function addExtra(key, value) {
+	return value ? key + ': ' + value + '\n' : '';
+}
+
+
+/** BEGIN TEST CASES **/
+var testCases = [
+	{
+		"type": "web",
+		"url": "https://findshisu.libsp.cn/#/searchList/bookDetails/96254981",
+		"items": [
+			{
+				"itemType": "book",
+				"title": "中外歌曲翻译史研究:1949-2019",
+				"creators": [],
+				"language": "zh-CN",
+				"libraryCatalog": "上海外国语大学图书馆",
+				"url": "https://findshisu.libsp.cn/#/searchList/bookDetails/96254981",
+				"attachments": [
+					{
+						"title": "上海外国语大学图书馆 Snapshot",
+						"mimeType": "text/html"
+					}
+				],
+				"tags": [],
+				"notes": [],
+				"seeAlso": []
+			}
+		]
+	},
+	{
+		"type": "web",
+		"url": "https://findshisu.libsp.cn/#/searchList/bookDetails/94756248",
+		"items": [
+			{
+				"itemType": "thesis",
+				"title": "中国\u201C未来\u201D话语的形成与流变——基于科幻文学翻译史的考察",
+				"creators": [],
+				"language": "zh-CN",
+				"libraryCatalog": "上海外国语大学图书馆",
+				"url": "https://findshisu.libsp.cn/#/searchList/bookDetails/94756248",
+				"attachments": [
+					{
+						"title": "上海外国语大学图书馆 Snapshot",
+						"mimeType": "text/html"
+					}
+				],
+				"tags": [],
+				"notes": [],
+				"seeAlso": []
+			}
+		]
+	},
+	{
+		"type": "web",
+		"url": "https://findshisu.libsp.cn/#/searchList/bookDetails/1257280",
+		"items": [
+			{
+				"itemType": "book",
+				"title": "翻译史研究.2014",
+				"creators": [],
+				"language": "zh-CN",
+				"libraryCatalog": "上海外国语大学图书馆",
+				"url": "https://findshisu.libsp.cn/#/searchList/bookDetails/1257280",
+				"attachments": [
+					{
+						"title": "上海外国语大学图书馆 Snapshot",
+						"mimeType": "text/html"
+					}
+				],
+				"tags": [],
+				"notes": [],
+				"seeAlso": []
+			}
+		]
+	},
+	{
+		"type": "web",
+		"url": "https://findshisu.libsp.cn/#/searchList",
+		"items": "multiple"
+	}
+]
+/** END TEST CASES **/

--- a/ShuKui.js
+++ b/ShuKui.js
@@ -1,7 +1,7 @@
 {
-	"translatorID": "f7a3c8d2-4e6b-4a9f-b1c3-7d8e2f5a6b4c",
+	"translatorID": "3d11a81c-266c-49bd-9ef2-a60183bb2f7a",
 	"label": "ShuKui",
-	"creator": "Zotero User",
+	"creator": "Daxoel",
 	"target": "^https?://(www\\.)?shukui\\.net",
 	"minVersion": "5.0",
 	"maxVersion": "",
@@ -9,13 +9,13 @@
 	"inRepository": true,
 	"translatorType": 4,
 	"browserSupport": "gcsibv",
-	"lastUpdated": "2026-07-15 00:00:00"
+	"lastUpdated": "2026-08-18 10:00:00"
 }
 
 /*
 	***** BEGIN LICENSE BLOCK *****
 
-	Copyright © 2026 Zotero User
+	Copyright © 2026 4965898
 
 	This file is part of Zotero.
 
@@ -46,14 +46,14 @@ function detectWeb(doc, url) {
 }
 
 function getSearchResults(doc, checkOnly) {
-	var items = {};
-	var found = false;
-	var links = doc.querySelectorAll('a[href*="/book/"]');
-	for (var i = 0; i < links.length; i++) {
-		var href = links[i].href;
+	const items = {};
+	let found = false;
+	const links = doc.querySelectorAll('a[href*="/book/"]');
+	for (const link of links) {
+		const href = link.href;
 		if (!/shukui\.net\/book\/\d+\.html/i.test(href)) continue;
 		if (items[href]) continue;
-		var title = ZU.trimInternal(links[i].textContent).replace(/\*/g, '').trim();
+		const title = ZU.trimInternal(link.textContent).replace(/\*/g, '').trim();
 		if (!title || title.length < 4) continue;
 		// Skip download/trial links
 		if (/下载|试读|购买|解压/.test(title)) continue;
@@ -64,17 +64,11 @@ function getSearchResults(doc, checkOnly) {
 	return found ? items : false;
 }
 
-function doWeb(doc, url) {
+async function doWeb(doc, url) {
 	if (detectWeb(doc, url) === 'multiple') {
-		var searchResults = getSearchResults(doc, false);
-		Zotero.selectItems(searchResults, function (items) {
-			if (!items) return;
-			var urls = [];
-			for (var itemUrl in items) {
-				urls.push(itemUrl);
-			}
-			ZU.processDocuments(urls, scrape);
-		});
+		const items = await Z.selectItems(getSearchResults(doc, false));
+		if (!items) return;
+		await processDocuments(Object.keys(items), scrape);
 	}
 	else {
 		scrape(doc, url);
@@ -82,32 +76,32 @@ function doWeb(doc, url) {
 }
 
 function scrape(doc, url) {
-	var item = new Zotero.Item('book');
+	const item = new Z.Item('book');
 	item.url = url;
 	item.libraryCatalog = '书葵网';
 	item.language = 'zh-CN';
 
 	// Title: from h1, remove "pdf电子书版本下载" suffix
-	var h1 = doc.querySelector('h1');
-	var title = h1 ? ZU.trimInternal(h1.textContent) : (doc.title || '');
+	const h1 = doc.querySelector('h1');
+	let title = h1 ? ZU.trimInternal(h1.textContent) : (doc.title || '');
 	title = title.replace(/\s*pdf电子书(版本)?下载$/i, '').trim();
 	if (!title) title = doc.title || 'Untitled';
 	item.title = title;
 
 	// Parse metadata from <li> items
-	var fields = parseListFields(doc);
+	const fields = parseListFields(doc);
 
 	// Author: try labeled field first, then unlabeled items
-	var author = getField(fields, ['作者', '责任者']);
+	let author = getField(fields, ['作者', '责任者']);
 	if (!author && fields._unlabeled && fields._unlabeled.length > 0) {
 		author = fields._unlabeled[0];
 	}
 	addCreators(item, author);
 
 	// Publisher: "北京：人民教育出版社" → place:publisher
-	var publisher = getField(fields, ['出版社', '出版发行']);
+	const publisher = getField(fields, ['出版社', '出版发行']);
 	if (publisher) {
-		var pubMatch = publisher.match(/^(.+?)[：:]\s*(.+)$/);
+		const pubMatch = publisher.match(/^(.+?)[：:]\s*(.+)$/);
 		if (pubMatch) {
 			item.place = pubMatch[1].trim();
 			item.publisher = pubMatch[2].trim();
@@ -118,27 +112,27 @@ function scrape(doc, url) {
 	}
 
 	// Date
-	var date = getField(fields, ['出版时间', '出版年', '出版日期']);
+	const date = getField(fields, ['出版时间', '出版年', '出版日期']);
 	if (date && date !== '未知') {
 		item.date = date;
 	}
 
 	// ISBN
-	var isbn = getField(fields, ['ISBN']);
+	const isbn = getField(fields, ['ISBN']);
 	if (isbn) {
-		var isbnMatch = isbn.match(/([\dXx-]{10,})/);
+		const isbnMatch = isbn.match(/([\dXx-]{10,})/);
 		if (isbnMatch) item.ISBN = isbnMatch[1];
 	}
 
 	// Pages
-	var pages = getField(fields, ['标注页数', '页数']);
+	const pages = getField(fields, ['标注页数', '页数']);
 	if (pages) {
-		var pageMatch = pages.match(/(\d+)\s*页/);
+		const pageMatch = pages.match(/(\d+)\s*页/);
 		if (pageMatch) item.numPages = pageMatch[1];
 	}
 
 	// Tags from subject keywords
-	var subject = getField(fields, ['主题词', '关键词']);
+	const subject = getField(fields, ['主题词', '关键词']);
 	if (subject) {
 		item.tags = subject.split(/[,，;；\-—－]/)
 			.map(function (t) { return t.trim(); })
@@ -146,26 +140,26 @@ function scrape(doc, url) {
 	}
 
 	// Extra: MD5, file size
-	var extraParts = [];
-	var md5 = getField(fields, ['MD5']);
+	const extraParts = [];
+	let md5 = getField(fields, ['MD5']);
 	// Fallback: search entire page text for MD5 hash pattern
 	if (!md5 && doc.body) {
-		var bodyText = doc.body.textContent || '';
-		var md5Match = bodyText.match(/MD5[^\d]*([a-fA-F0-9]{32})/);
+		const bodyText = doc.body.textContent || '';
+		const md5Match = bodyText.match(/MD5[^\d]*([a-fA-F0-9]{32})/);
 		if (md5Match) md5 = md5Match[1];
 	}
 	if (md5) extraParts.push('MD5: ' + md5);
-	var fileSize = getField(fields, ['文件大小']);
+	const fileSize = getField(fields, ['文件大小']);
 	if (fileSize) extraParts.push('File Size: ' + fileSize);
 	if (extraParts.length > 0) item.extra = extraParts.join('\n');
 
 	// Cover image
-	var imgs = doc.querySelectorAll('img');
-	for (var k = 0; k < imgs.length; k++) {
-		if (imgs[k].src && /doubaocdn|aka\.doubao/.test(imgs[k].src)) {
+	const imgs = doc.querySelectorAll('img');
+	for (const img of imgs) {
+		if (img.src && /doubaocdn|aka\.doubao/.test(img.src)) {
 			item.attachments.push({
 				title: 'Cover',
-				url: imgs[k].src,
+				url: img.src,
 				mimeType: 'image/jpeg'
 			});
 			break;
@@ -176,16 +170,16 @@ function scrape(doc, url) {
 }
 
 function parseListFields(doc) {
-	var fields = {};
-	var unlabeled = [];
-	var lis = doc.querySelectorAll('li');
-	for (var i = 0; i < lis.length; i++) {
-		var text = ZU.trimInternal(lis[i].textContent);
+	const fields = {};
+	const unlabeled = [];
+	const lis = doc.querySelectorAll('li');
+	for (const li of lis) {
+		const text = ZU.trimInternal(li.textContent);
 		if (!text) continue;
-		var match = text.match(/^([^：:]{1,12})[：:]\s*(.+)$/);
+		const match = text.match(/^([^：:]{1,12})[：:]\s*(.+)$/);
 		if (match) {
-			var label = match[1].trim();
-			var value = match[2].trim();
+			const label = match[1].trim();
+			const value = match[2].trim();
 			if (label && value) {
 				fields[label] = value;
 			}
@@ -203,13 +197,13 @@ function parseListFields(doc) {
 function getField(fields, labels) {
 	if (!Array.isArray(labels)) labels = [labels];
 	// Pass 1: exact match
-	for (var i = 0; i < labels.length; i++) {
-		if (fields[labels[i]]) return fields[labels[i]];
+	for (const label of labels) {
+		if (fields[label]) return fields[label];
 	}
 	// Pass 2: partial match
-	for (var j = 0; j < labels.length; j++) {
-		var re = new RegExp(labels[j]);
-		for (var key in fields) {
+	for (const label of labels) {
+		const re = new RegExp(label);
+		for (const key in fields) {
 			if (key === '_unlabeled') continue;
 			if (re.test(key)) return fields[key];
 		}
@@ -222,13 +216,13 @@ function addCreators(item, authorString) {
 	// Remove nationality prefix like （中国）or (澳)
 	authorString = authorString.replace(/^[（(][\u4e00-\u9fa5]{1,3}[）)]\s*/, '');
 	// Split by commas/semicolons, but not inside ASCII parens
-	var names = authorString.split(/[,，;；](?![^(]*\))/);
+	const names = authorString.split(/[,，;；](?![^(]*\))/);
 
 	// Merge Chinese name + immediately following ASCII Western parenthetical
 	// e.g. ["皮姆", "(Pym,Anthony)"] → ["皮姆(Pym,Anthony)"]
-	var mergedNames = [];
-	for (var i = 0; i < names.length; i++) {
-		var n = names[i].trim();
+	const mergedNames = [];
+	for (const rawName of names) {
+		const n = rawName.trim();
 		if (!n) continue;
 		if (mergedNames.length > 0 && /^\([A-Za-z]/.test(n)
 			&& /[\u4e00-\u9fa5]/.test(mergedNames[mergedNames.length - 1])) {
@@ -239,11 +233,11 @@ function addCreators(item, authorString) {
 		}
 	}
 
-	for (var j = 0; j < mergedNames.length; j++) {
-		var name = mergedNames[j].trim();
+	for (const rawName of mergedNames) {
+		let name = rawName.trim();
 		if (!name) continue;
 		// Strip trailing role markers (per name, repeated for multi-char markers)
-		var prev;
+		let prev;
 		do {
 			prev = name;
 			name = name.replace(/(组编|主编|编著|编译|校订|整理|等著|等编|等译|著|编|撰|校|译|注|辑)\s*$/, '').trim();
@@ -252,16 +246,16 @@ function addCreators(item, authorString) {
 
 		// Check for Western name in parens (ASCII or Chinese fullwidth)
 		// e.g. (Pym,Anthony) or 舒茨（SCHITZ，D.P.）
-		var westernMatch = name.match(/[（(]([A-Za-z][^）)]+)[）)]/);
+		const westernMatch = name.match(/[（(]([A-Za-z][^）)]+)[）)]/);
 		if (westernMatch) {
-			var westernName = westernMatch[1].replace(/，/g, ',');
-			var creator = ZU.cleanAuthor(westernName, 'author');
+			const westernName = westernMatch[1].replace(/，/g, ',');
+			const creator = ZU.cleanAuthor(westernName, 'author');
 			if (creator.lastName) {
 				item.creators.push(creator);
 				continue;
 			}
 			// Fallback: if cleanAuthor failed, use Chinese part
-			var chinesePart = name.replace(/[（(][^）)]*[）)]/g, '').trim();
+			const chinesePart = name.replace(/[（(][^）)]*[）)]/g, '').trim();
 			if (chinesePart && /[\u4e00-\u9fa5]/.test(chinesePart)) {
 				item.creators.push({
 					lastName: chinesePart,
@@ -285,7 +279,7 @@ function addCreators(item, authorString) {
 			});
 		}
 		else {
-			var creator2 = ZU.cleanAuthor(name, 'author');
+			const creator2 = ZU.cleanAuthor(name, 'author');
 			if (creator2.lastName) {
 				item.creators.push(creator2);
 			}
@@ -356,11 +350,11 @@ var testCases = [
 				"place": "北京",
 				"publisher": "中国法制出版社",
 				"url": "https://www.shukui.net/book/930629.html",
-			"attachments": [],
-			"tags": [
-				{ "tag": "心理学" },
-				{ "tag": "通俗读物" }
-			],
+				"attachments": [],
+				"tags": [
+					{ "tag": "心理学" },
+					{ "tag": "通俗读物" }
+				],
 				"notes": [],
 				"seeAlso": []
 			}

--- a/ShuKui.js
+++ b/ShuKui.js
@@ -1,0 +1,375 @@
+{
+	"translatorID": "f7a3c8d2-4e6b-4a9f-b1c3-7d8e2f5a6b4c",
+	"label": "ShuKui",
+	"creator": "Zotero User",
+	"target": "^https?://(www\\.)?shukui\\.net",
+	"minVersion": "5.0",
+	"maxVersion": "",
+	"priority": 100,
+	"inRepository": true,
+	"translatorType": 4,
+	"browserSupport": "gcsibv",
+	"lastUpdated": "2026-07-15 00:00:00"
+}
+
+/*
+	***** BEGIN LICENSE BLOCK *****
+
+	Copyright © 2026 Zotero User
+
+	This file is part of Zotero.
+
+	Zotero is free software: you can redistribute it and/or modify
+	it under the terms of the GNU Affero General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	Zotero is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+	GNU Affero General Public License for more details.
+
+	You should have received a copy of the GNU Affero General Public License
+	along with Zotero. If not, see <http://www.gnu.org/licenses/>.
+
+	***** END LICENSE BLOCK *****
+*/
+
+function detectWeb(doc, url) {
+	if (/shukui\.net\/book\/\d+\.html/i.test(url)) {
+		return 'book';
+	}
+	if (/shukui\.net\/so\/search\.php/i.test(url) && getSearchResults(doc, true)) {
+		return 'multiple';
+	}
+	return false;
+}
+
+function getSearchResults(doc, checkOnly) {
+	var items = {};
+	var found = false;
+	var links = doc.querySelectorAll('a[href*="/book/"]');
+	for (var i = 0; i < links.length; i++) {
+		var href = links[i].href;
+		if (!/shukui\.net\/book\/\d+\.html/i.test(href)) continue;
+		if (items[href]) continue;
+		var title = ZU.trimInternal(links[i].textContent).replace(/\*/g, '').trim();
+		if (!title || title.length < 4) continue;
+		// Skip download/trial links
+		if (/下载|试读|购买|解压/.test(title)) continue;
+		if (checkOnly) return true;
+		found = true;
+		items[href] = title;
+	}
+	return found ? items : false;
+}
+
+function doWeb(doc, url) {
+	if (detectWeb(doc, url) === 'multiple') {
+		var searchResults = getSearchResults(doc, false);
+		Zotero.selectItems(searchResults, function (items) {
+			if (!items) return;
+			var urls = [];
+			for (var itemUrl in items) {
+				urls.push(itemUrl);
+			}
+			ZU.processDocuments(urls, scrape);
+		});
+	}
+	else {
+		scrape(doc, url);
+	}
+}
+
+function scrape(doc, url) {
+	var item = new Zotero.Item('book');
+	item.url = url;
+	item.libraryCatalog = '书葵网';
+	item.language = 'zh-CN';
+
+	// Title: from h1, remove "pdf电子书版本下载" suffix
+	var h1 = doc.querySelector('h1');
+	var title = h1 ? ZU.trimInternal(h1.textContent) : (doc.title || '');
+	title = title.replace(/\s*pdf电子书(版本)?下载$/i, '').trim();
+	if (!title) title = doc.title || 'Untitled';
+	item.title = title;
+
+	// Parse metadata from <li> items
+	var fields = parseListFields(doc);
+
+	// Author: try labeled field first, then unlabeled items
+	var author = getField(fields, ['作者', '责任者']);
+	if (!author && fields._unlabeled && fields._unlabeled.length > 0) {
+		author = fields._unlabeled[0];
+	}
+	addCreators(item, author);
+
+	// Publisher: "北京：人民教育出版社" → place:publisher
+	var publisher = getField(fields, ['出版社', '出版发行']);
+	if (publisher) {
+		var pubMatch = publisher.match(/^(.+?)[：:]\s*(.+)$/);
+		if (pubMatch) {
+			item.place = pubMatch[1].trim();
+			item.publisher = pubMatch[2].trim();
+		}
+		else {
+			item.publisher = publisher;
+		}
+	}
+
+	// Date
+	var date = getField(fields, ['出版时间', '出版年', '出版日期']);
+	if (date && date !== '未知') {
+		item.date = date;
+	}
+
+	// ISBN
+	var isbn = getField(fields, ['ISBN']);
+	if (isbn) {
+		var isbnMatch = isbn.match(/([\dXx-]{10,})/);
+		if (isbnMatch) item.ISBN = isbnMatch[1];
+	}
+
+	// Pages
+	var pages = getField(fields, ['标注页数', '页数']);
+	if (pages) {
+		var pageMatch = pages.match(/(\d+)\s*页/);
+		if (pageMatch) item.numPages = pageMatch[1];
+	}
+
+	// Tags from subject keywords
+	var subject = getField(fields, ['主题词', '关键词']);
+	if (subject) {
+		item.tags = subject.split(/[,，;；\-—－]/)
+			.map(function (t) { return t.trim(); })
+			.filter(function (t) { return t; });
+	}
+
+	// Extra: MD5, file size
+	var extraParts = [];
+	var md5 = getField(fields, ['MD5']);
+	// Fallback: search entire page text for MD5 hash pattern
+	if (!md5 && doc.body) {
+		var bodyText = doc.body.textContent || '';
+		var md5Match = bodyText.match(/MD5[^\d]*([a-fA-F0-9]{32})/);
+		if (md5Match) md5 = md5Match[1];
+	}
+	if (md5) extraParts.push('MD5: ' + md5);
+	var fileSize = getField(fields, ['文件大小']);
+	if (fileSize) extraParts.push('File Size: ' + fileSize);
+	if (extraParts.length > 0) item.extra = extraParts.join('\n');
+
+	// Cover image
+	var imgs = doc.querySelectorAll('img');
+	for (var k = 0; k < imgs.length; k++) {
+		if (imgs[k].src && /doubaocdn|aka\.doubao/.test(imgs[k].src)) {
+			item.attachments.push({
+				title: 'Cover',
+				url: imgs[k].src,
+				mimeType: 'image/jpeg'
+			});
+			break;
+		}
+	}
+
+	item.complete();
+}
+
+function parseListFields(doc) {
+	var fields = {};
+	var unlabeled = [];
+	var lis = doc.querySelectorAll('li');
+	for (var i = 0; i < lis.length; i++) {
+		var text = ZU.trimInternal(lis[i].textContent);
+		if (!text) continue;
+		var match = text.match(/^([^：:]{1,12})[：:]\s*(.+)$/);
+		if (match) {
+			var label = match[1].trim();
+			var value = match[2].trim();
+			if (label && value) {
+				fields[label] = value;
+			}
+		}
+		else if (/(著|编|组编|主编|编著|撰|校|译|整理|编译|校订|辑|注)$/.test(text)
+			|| (/[,，；;]/.test(text) && /[\u4e00-\u9fa5]/.test(text))) {
+			// Unlabeled item that looks like author info
+			unlabeled.push(text);
+		}
+	}
+	fields._unlabeled = unlabeled;
+	return fields;
+}
+
+function getField(fields, labels) {
+	if (!Array.isArray(labels)) labels = [labels];
+	// Pass 1: exact match
+	for (var i = 0; i < labels.length; i++) {
+		if (fields[labels[i]]) return fields[labels[i]];
+	}
+	// Pass 2: partial match
+	for (var j = 0; j < labels.length; j++) {
+		var re = new RegExp(labels[j]);
+		for (var key in fields) {
+			if (key === '_unlabeled') continue;
+			if (re.test(key)) return fields[key];
+		}
+	}
+	return '';
+}
+
+function addCreators(item, authorString) {
+	if (!authorString) return;
+	// Remove nationality prefix like （中国）or (澳)
+	authorString = authorString.replace(/^[（(][\u4e00-\u9fa5]{1,3}[）)]\s*/, '');
+	// Split by commas/semicolons, but not inside ASCII parens
+	var names = authorString.split(/[,，;；](?![^(]*\))/);
+
+	// Merge Chinese name + immediately following ASCII Western parenthetical
+	// e.g. ["皮姆", "(Pym,Anthony)"] → ["皮姆(Pym,Anthony)"]
+	var mergedNames = [];
+	for (var i = 0; i < names.length; i++) {
+		var n = names[i].trim();
+		if (!n) continue;
+		if (mergedNames.length > 0 && /^\([A-Za-z]/.test(n)
+			&& /[\u4e00-\u9fa5]/.test(mergedNames[mergedNames.length - 1])) {
+			mergedNames[mergedNames.length - 1] += n;
+		}
+		else {
+			mergedNames.push(n);
+		}
+	}
+
+	for (var j = 0; j < mergedNames.length; j++) {
+		var name = mergedNames[j].trim();
+		if (!name) continue;
+		// Strip trailing role markers (per name, repeated for multi-char markers)
+		var prev;
+		do {
+			prev = name;
+			name = name.replace(/(组编|主编|编著|编译|校订|整理|等著|等编|等译|著|编|撰|校|译|注|辑)\s*$/, '').trim();
+		} while (name !== prev);
+		if (!name) continue;
+
+		// Check for Western name in parens (ASCII or Chinese fullwidth)
+		// e.g. (Pym,Anthony) or 舒茨（SCHITZ，D.P.）
+		var westernMatch = name.match(/[（(]([A-Za-z][^）)]+)[）)]/);
+		if (westernMatch) {
+			var westernName = westernMatch[1].replace(/，/g, ',');
+			var creator = ZU.cleanAuthor(westernName, 'author');
+			if (creator.lastName) {
+				item.creators.push(creator);
+				continue;
+			}
+			// Fallback: if cleanAuthor failed, use Chinese part
+			var chinesePart = name.replace(/[（(][^）)]*[）)]/g, '').trim();
+			if (chinesePart && /[\u4e00-\u9fa5]/.test(chinesePart)) {
+				item.creators.push({
+					lastName: chinesePart,
+					creatorType: 'author',
+					fieldMode: 1
+				});
+				continue;
+			}
+		}
+
+		// Remove parenthetical content (descriptions like 专业心理作家)
+		name = name.replace(/\([^)]*\)/g, '').trim();
+		name = name.replace(/[（(][^）)]*[）)]/g, '').trim();
+		if (!name) continue;
+
+		if (/[\u4e00-\u9fa5]/.test(name)) {
+			item.creators.push({
+				lastName: name,
+				creatorType: 'author',
+				fieldMode: 1
+			});
+		}
+		else {
+			var creator2 = ZU.cleanAuthor(name, 'author');
+			if (creator2.lastName) {
+				item.creators.push(creator2);
+			}
+		}
+	}
+}
+
+/** BEGIN TEST CASES **/
+var testCases = [
+	{
+		"type": "web",
+		"url": "https://www.shukui.net/book/3190990.html",
+		"items": [
+			{
+				"itemType": "book",
+				"title": "朱智贤心理学文选 理论心理学、发展心理学、心理学小品集",
+				"creators": [
+					{
+						"firstName": "",
+						"lastName": "朱智贤",
+						"creatorType": "author",
+						"fieldMode": 1
+					}
+				],
+				"date": "1989",
+				"ISBN": "7107104454",
+				"extra": "MD5: 74d7cebcf084820df3a84348a99c7a65\nFile Size: 20MB",
+				"language": "zh-CN",
+				"libraryCatalog": "书葵网",
+				"numPages": "519",
+				"place": "北京",
+				"publisher": "人民教育出版社",
+				"url": "https://www.shukui.net/book/3190990.html",
+				"attachments": [],
+				"tags": [],
+				"notes": [],
+				"seeAlso": []
+			}
+		]
+	},
+	{
+		"type": "web",
+		"url": "https://www.shukui.net/book/930629.html",
+		"items": [
+			{
+				"itemType": "book",
+				"title": "心理学与你 带你走进心理学世界",
+				"creators": [
+					{
+						"firstName": "",
+						"lastName": "隋岩",
+						"creatorType": "author",
+						"fieldMode": 1
+					},
+					{
+						"firstName": "",
+						"lastName": "京师心智",
+						"creatorType": "author",
+						"fieldMode": 1
+					}
+				],
+				"date": "2013",
+				"ISBN": "9787509345269",
+				"extra": "MD5: cdee8396c8924ce3f1713f0570f6cb75\nFile Size: 49MB",
+				"language": "zh-CN",
+				"libraryCatalog": "书葵网",
+				"numPages": "248",
+				"place": "北京",
+				"publisher": "中国法制出版社",
+				"url": "https://www.shukui.net/book/930629.html",
+			"attachments": [],
+			"tags": [
+				{ "tag": "心理学" },
+				{ "tag": "通俗读物" }
+			],
+				"notes": [],
+				"seeAlso": []
+			}
+		]
+	},
+	{
+		"type": "web",
+		"url": "https://www.shukui.net/so/search.php?q=%E5%BF%83%E7%90%86%E5%AD%A6",
+		"items": "multiple"
+	}
+]
+/** END TEST CASES **/

--- a/Wikimedia Commons.js
+++ b/Wikimedia Commons.js
@@ -1,0 +1,585 @@
+{
+	"translatorID": "c70055c3-a525-45db-8e37-726c6c2ad034",
+	"label": "Wikimedia Commons",
+	"creator": "Sebastian Karcher",
+	"target": "^https?://commons\\.wikimedia\\.org",
+	"minVersion": "2.1.9",
+	"maxVersion": "",
+	"priority": 100,
+	"inRepository": true,
+	"translatorType": 4,
+	"browserSupport": "gcsibv",
+	"lastUpdated": "2026-07-10 22:10:00"
+}
+
+/*
+	***** BEGIN LICENSE BLOCK *****
+
+	Copyright © 2014-2019 Sebastian Karcher
+
+	This file is part of Zotero.
+
+	Zotero is free software: you can redistribute it and/or modify
+	it under the terms of the GNU Affero General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	Zotero is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+	GNU Affero General Public License for more details.
+
+	You should have received a copy of the GNU Affero General Public License
+	along with Zotero. If not, see <http://www.gnu.org/licenses/>.
+
+	***** END LICENSE BLOCK *****
+*/
+
+// eslint-disable-next-line
+/* FW LINE 59:b820c6d */ function flatten(t){var e=new Array;for(var i in t){var r=t[i];r instanceof Array?e=e.concat(flatten(r)):e.push(r)}return e}var FW={_scrapers:new Array};FW._Base=function(){this.callHook=function(t,e,i,r){if("object"==typeof this.hooks){var n=this.hooks[t];"function"==typeof n&&n(e,i,r)}},this.evaluateThing=function(t,e,i){var r=typeof t;if("object"===r){if(t instanceof Array){var n=this.evaluateThing,a=t.map(function(t){return n(t,e,i)});return flatten(a)}return t.evaluate(e,i)}return"function"===r?t(e,i):t},this.makeItems=function(t,e,i,r,n){n()}},FW.Scraper=function(t){FW._scrapers.push(new FW._Scraper(t))},FW._Scraper=function(t){for(x in t)this[x]=t[x];this._singleFieldNames=["abstractNote","applicationNumber","archive","archiveLocation","artworkMedium","artworkSize","assignee","audioFileType","audioRecordingType","billNumber","blogTitle","bookTitle","callNumber","caseName","code","codeNumber","codePages","codeVolume","committee","company","conferenceName","country","court","date","dateDecided","dateEnacted","dictionaryTitle","distributor","docketNumber","documentNumber","DOI","edition","encyclopediaTitle","episodeNumber","extra","filingDate","firstPage","forumTitle","genre","history","institution","interviewMedium","ISBN","ISSN","issue","issueDate","issuingAuthority","journalAbbreviation","label","language","legalStatus","legislativeBody","letterType","libraryCatalog","manuscriptType","mapType","medium","meetingName","nameOfAct","network","number","numberOfVolumes","numPages","pages","patentNumber","place","postType","presentationType","priorityNumbers","proceedingsTitle","programTitle","programmingLanguage","publicLawNumber","publicationTitle","publisher","references","reportNumber","reportType","reporter","reporterVolume","rights","runningTime","scale","section","series","seriesNumber","seriesText","seriesTitle","session","shortTitle","studio","subject","system","thesisType","title","type","university","url","version","videoRecordingType","volume","websiteTitle","websiteType"],this._makeAttachments=function(t,e,i,r){if(i instanceof Array)i.forEach(function(i){this._makeAttachments(t,e,i,r)},this);else if("object"==typeof i){var n=i.urls||i.url,a=i.types||i.type,s=i.titles||i.title,o=i.snapshots||i.snapshot,u=this.evaluateThing(n,t,e),l=this.evaluateThing(s,t,e),c=this.evaluateThing(a,t,e),h=this.evaluateThing(o,t,e);u instanceof Array||(u=[u]);for(var f in u){var p,m,v,d=u[f];p=c instanceof Array?c[f]:c,m=l instanceof Array?l[f]:l,v=h instanceof Array?h[f]:h,r.attachments.push({url:d,title:m,mimeType:p,snapshot:v})}}},this.makeItems=function(t,e,i,r,n){var a=new Zotero.Item(this.itemType);a.url=e;for(var s in this._singleFieldNames){var o=this._singleFieldNames[s];if(this[o]){var u=this.evaluateThing(this[o],t,e);u instanceof Array?a[o]=u[0]:a[o]=u}}var l=["creators","tags"];for(var c in l){var h=l[c],f=this.evaluateThing(this[h],t,e);if(f)for(var p in f)a[h].push(f[p])}this._makeAttachments(t,e,this.attachments,a),r(a,this,t,e),n()}},FW._Scraper.prototype=new FW._Base,FW.MultiScraper=function(t){FW._scrapers.push(new FW._MultiScraper(t))},FW._MultiScraper=function(t){for(x in t)this[x]=t[x];this._mkSelectItems=function(t,e){var i=new Object;for(var r in t)i[e[r]]=t[r];return i},this._selectItems=function(t,e,i){var r=new Array;Zotero.selectItems(this._mkSelectItems(t,e),function(t){for(var e in t)r.push(e);i(r)})},this._mkAttachments=function(t,e,i){var r=this.evaluateThing(this.attachments,t,e),n=new Object;if(r)for(var a in i)n[i[a]]=r[a];return n},this._makeChoices=function(t,e,i,r,n){if(t instanceof Array)t.forEach(function(t){this._makeTitlesUrls(t,e,i,r,n)},this);else if("object"==typeof t){var a=t.urls||t.url,s=t.titles||t.title,o=this.evaluateThing(a,e,i),u=this.evaluateThing(s,e,i),l=u instanceof Array;o instanceof Array||(o=[o]);for(var c in o){var h,f=o[c];h=l?u[c]:u,n.push(f),r.push(h)}}},this.makeItems=function(t,e,i,r,n){if(this.beforeFilter){var a=this.beforeFilter(t,e);if(a!=e)return void this.makeItems(t,a,i,r,n)}var s=[],o=[];this._makeChoices(this.choices,t,e,s,o);var u=this._mkAttachments(t,e,o),l=this.itemTrans;this._selectItems(s,o,function(t){if(t){var e=function(t){var e=t.documentURI,i=l;void 0===i&&(i=FW.getScraper(t,e)),void 0===i||i.makeItems(t,e,u[e],r,function(){})};Zotero.Utilities.processDocuments(t,e,n)}else n()})}},FW._MultiScraper.prototype=new FW._Base,FW.WebDelegateTranslator=function(t){return new FW._WebDelegateTranslator(t)},FW._WebDelegateTranslator=function(t){for(x in t)this[x]=t[x];this.makeItems=function(t,e,i,r,n){var a=this,s=Zotero.loadTranslator("web");s.setHandler("itemDone",function(i,n){r(n,a,t,e)}),s.setDocument(t),this.translatorId?(s.setTranslator(this.translatorId),s.translate()):(s.setHandler("translators",function(t,e){e.length&&(s.setTranslator(e[0]),s.translate())}),s.getTranslators()),n()}},FW._WebDelegateTranslator.prototype=new FW._Base,FW._StringMagic=function(){this._filters=new Array,this.addFilter=function(t){return this._filters.push(t),this},this.split=function(t){return this.addFilter(function(e){return e.split(t).filter(function(t){return""!=t})})},this.replace=function(t,e,i){return this.addFilter(function(r){return"string"!=typeof r?r:r.match(t)?r.replace(t,e,i):r})},this.prepend=function(t){return this.replace(/^/,t)},this.append=function(t){return this.replace(/$/,t)},this.remove=function(t,e){return this.replace(t,"",e)},this.trim=function(){return this.addFilter(function(t){return Zotero.Utilities.trim(t)})},this.trimInternal=function(){return this.addFilter(function(t){return Zotero.Utilities.trimInternal(t)})},this.match=function(t,e){return e||(e=0),this.addFilter(function(i){var r=i.match(t);return void 0===r||null===r?void 0:r[e]})},this.cleanAuthor=function(t,e){return this.addFilter(function(i){return"string"!=typeof i?i:Zotero.Utilities.cleanAuthor(i,t,e)})},this.key=function(t){return this.addFilter(function(e){return e[t]})},this.capitalizeTitle=function(){return this.addFilter(function(t){return Zotero.Utilities.capitalizeTitle(t)})},this.unescapeHTML=function(){return this.addFilter(function(t){return Zotero.Utilities.unescapeHTML(t)})},this.unescape=function(){return this.addFilter(function(t){return unescape(t)})},this._applyFilters=function(t,e){for(i in this._filters){t=flatten(t),t=t.filter(function(t){return void 0!==t&&null!==t});for(var r=0;r<t.length;r++)try{if(void 0===t[r]||null===t[r])continue;t[r]=this._filters[i](t[r],e)}catch(n){t[r]=void 0,Zotero.debug("Caught exception "+n+"on filter: "+this._filters[i])}t=t.filter(function(t){return void 0!==t&&null!==t})}return flatten(t)}},FW.PageText=function(){return new FW._PageText},FW._PageText=function(){this._filters=new Array,this.evaluate=function(t){var e=[t.documentElement.innerHTML];return e=this._applyFilters(e,t),0==e.length?!1:e}},FW._PageText.prototype=new FW._StringMagic,FW.Url=function(){return new FW._Url},FW._Url=function(){this._filters=new Array,this.evaluate=function(t,e){var i=[e];return i=this._applyFilters(i,t),0==i.length?!1:i}},FW._Url.prototype=new FW._StringMagic,FW.Xpath=function(t){return new FW._Xpath(t)},FW._Xpath=function(t){this._xpath=t,this._filters=new Array,this.text=function(){var t=function(t){return"object"==typeof t&&t.textContent?t.textContent:t};return this.addFilter(t),this},this.sub=function(t){var e=function(e,i){var r=i.evaluate(t,e,null,XPathResult.ANY_TYPE,null);return r?r.iterateNext():void 0};return this.addFilter(e),this},this.evaluate=function(t){var e=t.evaluate(this._xpath,t,null,XPathResult.ANY_TYPE,null),i=e.resultType,r=new Array;if(i==XPathResult.STRING_TYPE)r.push(e.stringValue);else if(i==XPathResult.BOOLEAN_TYPE)r.push(e.booleanValue);else if(i==XPathResult.NUMBER_TYPE)r.push(e.numberValue);else if(i==XPathResult.ORDERED_NODE_ITERATOR_TYPE||i==XPathResult.UNORDERED_NODE_ITERATOR_TYPE)for(var n;n=e.iterateNext();)r.push(n);return r=this._applyFilters(r,t),0==r.length?!1:r}},FW._Xpath.prototype=new FW._StringMagic,FW.detectWeb=function(t,e){for(var i in FW._scrapers){var r=FW._scrapers[i],n=r.evaluateThing(r.itemType,t,e),a=r.evaluateThing(r.detect,t,e);if(a.length>0&&a[0])return n}},FW.getScraper=function(t,e){var i=FW.detectWeb(t,e);return FW._scrapers.filter(function(r){return r.evaluateThing(r.itemType,t,e)==i&&r.evaluateThing(r.detect,t,e)})[0]},FW.doWeb=function(t,e){var i=FW.getScraper(t,e);i.makeItems(t,e,[],function(t,e,i,r){e.callHook("scraperDone",t,i,r),t.title||(t.title=""),t.complete()},function(){Zotero.done()}),Zotero.wait()};
+var BOOK_EXT_REGEX = /\.(pdf|djvu|epub|mobi)$/i;
+
+function isBookPage(doc, url) {
+	return /\/wiki\/File:/.test(url) && BOOK_EXT_REGEX.test(url) &&
+		doc.querySelector('#fileinfotpl_book_publisher, #fileinfotpl_book_language, #fileinfotpl_art_title, #fileinfotpl_aut');
+}
+
+function isSearchResultsPage(doc, url) {
+	if (!/Special:Search/.test(url)) return false;
+	var params = parseUrlParams(url);
+	return !!(params.search && params.search.trim());
+}
+
+function parseUrlParams(url) {
+	var params = {};
+	var query = url.split('?')[1] || '';
+	if (!query) return params;
+	var parts = query.split('&');
+	for (var i = 0; i < parts.length; i++) {
+		var pair = parts[i].split('=');
+		if (pair.length < 2) continue;
+		var key = decodeURIComponent(pair[0]);
+		var value = decodeURIComponent(pair.slice(1).join('=').replace(/\+/g, ' '));
+		params[key] = value;
+	}
+	return params;
+}
+
+function getSearchResults(url, callback) {
+	var params = parseUrlParams(url);
+	var searchTerm = params.search;
+	if (!searchTerm) {
+		callback({});
+		return;
+	}
+
+	var namespaces = [];
+	for (var key in params) {
+		var m = key.match(/^ns(\d+)$/);
+		if (m && params[key] === '1') namespaces.push(m[1]);
+	}
+	var ns = namespaces.length ? namespaces.join('|') : '6';
+	var apiUrl = 'https://commons.wikimedia.org/w/api.php?action=query&list=search&srsearch='
+		+ encodeURIComponent(searchTerm)
+		+ '&srnamespace=' + ns
+		+ '&srlimit=50&format=json';
+
+	ZU.doGet(apiUrl, function (respText) {
+		var data;
+		try {
+			data = JSON.parse(respText);
+		}
+		catch (e) {
+			Zotero.debug('Wikimedia Commons: failed to parse search API response: ' + e);
+		}
+
+		var items = {};
+		var results = data && data.query && data.query.search || [];
+		for (var i = 0; i < results.length; i++) {
+			var title = results[i].title;
+			if (!title || !/^File:/i.test(title)) continue;
+			if (!BOOK_EXT_REGEX.test(title)) continue;
+			var pageTitle = title.replace(/ /g, '_');
+			var itemUrl = 'https://commons.wikimedia.org/wiki/' + encodeURIComponent(pageTitle).replace(/%2F/g, '/');
+			var display = title.replace(/^File:/i, '').replace(/_/g, ' ');
+			items[itemUrl] = display;
+		}
+		callback(items);
+	});
+}
+
+function getFilenameFromUrl(url) {
+	var decoded = decodeURIComponent(url);
+	var match = decoded.match(/\/wiki\/File:([^#?]+)/);
+	return match ? match[1] : '';
+}
+
+function getBookAttachmentMeta(filename) {
+	var extMatch = filename.match(/\.([^.]+)$/);
+	var ext = extMatch ? extMatch[1].toLowerCase() : '';
+	var mimeType = 'application/octet-stream';
+	if (ext === 'pdf') mimeType = 'application/pdf';
+	else if (ext === 'djvu') mimeType = 'image/vnd.djvu';
+	else if (ext === 'epub') mimeType = 'application/epub+zip';
+	else if (ext === 'mobi') mimeType = 'application/x-mobipocket-ebook';
+	return {
+		ext: ext,
+		title: ext ? 'Wikimedia Commons ' + ext.toUpperCase() : 'Wikimedia Commons File',
+		mimeType: mimeType
+	};
+}
+
+function textContent(doc, selector) {
+	var el = doc.querySelector(selector);
+	return el ? el.textContent : '';
+}
+
+function normalizeUrl(url) {
+	if (!url || typeof url !== 'string') return url;
+	if (/^https?:\/\//.test(url)) return url;
+	if (/^\/\//.test(url)) return 'https:' + url;
+	if (/^\//.test(url)) return 'https://commons.wikimedia.org' + url;
+	return url;
+}
+
+function parseBookTemplate(wikitext) {
+	var params = {};
+	var match = wikitext.match(/\{\{\s*Book\s*([\s\S]*?)\n?\}\}/i);
+	if (!match) return params;
+
+	var lines = match[1].split('\n');
+	var currentKey = null;
+	for (var i = 0; i < lines.length; i++) {
+		var line = lines[i];
+		var paramMatch = line.match(/^\s*\|\s*([^\n=]+?)\s*=\s*(.*)$/);
+		if (paramMatch) {
+			currentKey = paramMatch[1].trim();
+			params[currentKey] = paramMatch[2].trim();
+		}
+		else if (currentKey && line.trim() && !/^\s*\|/.test(line)) {
+			params[currentKey] += '\n' + line.trim();
+		}
+	}
+	return params;
+}
+
+function getInfoField(wikitext, fieldName) {
+	var regex = new RegExp('\\{\\{\\s*Information field\\s*\\|\\s*name\\s*=\\s*' + fieldName + '\\s*\\|\\s*value\\s*=\\s*([^}]+)\\}\\}', 'i');
+	var m = wikitext.match(regex);
+	return m ? m[1].trim() : null;
+}
+
+function addCreators(item, value, defaultType) {
+	if (!value) return;
+	var creators = parseCreators(value, defaultType);
+	for (var i = 0; i < creators.length; i++) {
+		item.creators.push(creators[i]);
+	}
+}
+
+function parseCreators(authorString, defaultType) {
+	var creators = [];
+	var segments = authorString.split(/[；;]/);
+	for (var s = 0; s < segments.length; s++) {
+		var segment = segments[s].trim();
+		if (!segment) continue;
+
+		var creatorType = defaultType || 'author';
+
+		var cleaned = segment.replace(/(原著|著译|著譯|著|译|譯|翻|编译|編|编|撰|[註注]|整理|校订|校訂|主編|主编)/g, '').trim();
+		var names = cleaned.split(/[，,]/);
+		for (var i = 0; i < names.length; i++) {
+			var name = names[i].trim();
+			if (!name) continue;
+
+			var parenMatch = name.match(/^([^\(（]+)[\(（]/);
+			if (parenMatch && parenMatch[1].trim()) {
+				name = parenMatch[1].trim();
+			}
+			else if (/^[\(（]/.test(name)) {
+				name = name.replace(/^[\(（][^\)）]+[\)）]\s*/, '').trim();
+			}
+
+			if (name) {
+				creators.push({
+					firstName: '',
+					lastName: name,
+					creatorType: creatorType,
+					fieldMode: 1
+				});
+			}
+		}
+	}
+	return creators;
+}
+
+function mapLanguage(lang) {
+	if (!lang) return '';
+	lang = lang.toLowerCase();
+	if (lang === 'zh' || lang === 'chinese' || lang === '中文') return 'zh';
+	if (lang === 'zh-tw') return 'zh-TW';
+	if (lang === 'zh-cn') return 'zh-CN';
+	if (lang === 'en' || lang === 'english') return 'en';
+	return lang;
+}
+
+function scrapeBook(doc, url, doneCallback) {
+	var filename = getFilenameFromUrl(url);
+	var filePathUrl = 'https://commons.wikimedia.org/wiki/Special:FilePath/' + encodeURIComponent(filename);
+	var apiUrl = 'https://commons.wikimedia.org/w/api.php?action=parse&page=File:'
+		+ encodeURIComponent(filename) + '&prop=wikitext&format=json';
+
+	ZU.doGet(apiUrl, function (respText) {
+		var data;
+		try {
+			data = JSON.parse(respText);
+		}
+		catch (e) {
+			Zotero.debug('Wikimedia Commons: failed to parse API response: ' + e);
+		}
+
+		var wikitext = data && data.parse && data.parse.wikitext && data.parse.wikitext['*'] || '';
+		var params = parseBookTemplate(wikitext);
+
+		var item = new Zotero.Item('book');
+		item.url = url;
+		item.libraryCatalog = 'Wikimedia Commons';
+
+		item.title = params.Title || textContent(doc, 'h1#firstHeading') || '';
+		item.title = item.title.replace(/^File:/, '').replace(BOOK_EXT_REGEX, '').trim();
+
+		addCreators(item, params.Author, 'author');
+		addCreators(item, params.Translator, 'author');
+		addCreators(item, params.Editor, 'author');
+		addCreators(item, params.Illustrator, 'author');
+
+		if (params.Publisher) item.publisher = params.Publisher;
+		if (params['Publication date']) item.date = params['Publication date'];
+		if (params.City) item.place = params.City;
+		if (params.Edition) item.edition = params.Edition;
+		if (params.Language) item.language = mapLanguage(params.Language);
+
+		var pages = params.Pages || getInfoField(wikitext, 'Pages');
+		if (pages) item.numPages = String(pages);
+
+		var source = params.Source;
+		if (source) {
+			source = source.replace(/\{\{[^}]+\}\}/g, '').trim();
+			item.archive = source;
+		}
+
+		var attachMeta = getBookAttachmentMeta(filename);
+		item.attachments.push({
+			title: attachMeta.title,
+			url: filePathUrl,
+			mimeType: attachMeta.mimeType
+		});
+		item.attachments.push({
+			title: 'Wikimedia Commons Snapshot',
+			url: url,
+			mimeType: 'text/html',
+			snapshot: false
+		});
+
+		item.complete();
+		if (typeof doneCallback === 'function') doneCallback();
+	});
+}
+
+function detectWeb(doc, url) {
+	// Diff interface is not supported
+	if (new URLSearchParams(doc.location.search).get('diff')) {
+		return false;
+	}
+
+	if (isBookPage(doc, url)) return 'book';
+	if (isSearchResultsPage(doc, url)) return 'multiple';
+	return FW.detectWeb(doc, url);
+}
+
+function doWeb(doc, url) {
+	var itemType = detectWeb(doc, url);
+	if (itemType === 'book') {
+		scrapeBook(doc, url, function () { Zotero.done(); });
+		Zotero.wait();
+	}
+	else if (itemType === 'multiple') {
+		getSearchResults(url, function (items) {
+			if (!items || Object.keys(items).length === 0) {
+				Zotero.done();
+				return;
+			}
+			Zotero.selectItems(items, function (selected) {
+				if (!selected) {
+					Zotero.done();
+					return;
+				}
+				var urls = Object.keys(selected);
+				var completed = 0;
+				ZU.processDocuments(urls, function (newDoc, newUrl) {
+					scrapeBook(newDoc, newUrl, function () {
+						completed++;
+						if (completed >= urls.length) Zotero.done();
+					});
+				});
+			});
+		});
+		Zotero.wait();
+	}
+	else {
+		return FW.doWeb(doc, url);
+	}
+}
+
+/*
+	***** BEGIN LICENSE BLOCK *****
+
+	Wikimedia Commons Translator
+	Copyright © 2012 Sebastian Karcher
+
+	This file is part of Zotero.
+
+	Zotero is free software: you can redistribute it and/or modify
+	it under the terms of the GNU Affero General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	Zotero is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+	GNU Affero General Public License for more details.
+
+	You should have received a copy of the GNU Affero General Public License
+	along with Zotero. If not, see <http://www.gnu.org/licenses/>.
+
+	***** END LICENSE BLOCK *****
+*/
+
+
+/**Art Images*/
+FW.Scraper({
+	itemType : 'artwork',
+	detect : FW.Xpath('//td[@id="fileinfotpl_art_title" or @id="fileinfotpl_desc"]'),
+	title : FW.Xpath('//td[@id="fileinfotpl_art_title" or @id="fileinfotpl_desc"]/following-sibling::td').text().trim().remove(/\n.+/g),
+	attachments : [{
+  	url : FW.Url(),
+  	title : "Wikimedia Snapshot",
+  	type : "text/html"
+	},
+	{
+		url : FW.Xpath('//div[@id="file"]/a/@href').text(),
+		title : "Wikimedia Image"
+	}],
+	creators : FW.Xpath('//tr/td[@id="fileinfotpl_aut"]/following-sibling::td').text().remove(/\n/g).remove(/\(.+/).cleanAuthor("author"),
+	artworkSize : FW.Xpath('//tr/td[@id="fileinfotpl_art_dimensions"]/following-sibling::td').text(),
+	artworkMedium : FW.Xpath('//tr/td[@id="fileinfotpl_art_medium"]/following-sibling::td').text(),
+	date : FW.Xpath('//tr/td[@id="fileinfotpl_date"]/following-sibling::td').text(),
+	archive : FW.Xpath('//tr/td[@id="fileinfotpl_art_gallery"]/following-sibling::td').text().trim().remove(/\n.+/g),
+	rights : FW.Xpath('//table[@class="licensetpl" or @class="layouttemplate licensetpl"]/tbody/tr/td[2]|//table[@class="licensetpl" or @class="layouttemplate licensetpl"]/tbody/tr/td/span').text(),
+
+	hooks : {
+		"scraperDone": function  (item,doc, url) {
+			if (!item.archive) item.archive = ZU.xpathText(doc, '//tr/td[@id="fileinfotpl_src"]/following-sibling::td');
+			item.date = item.date ? item.date : item.runningTime;
+			item.runningTime = undefined;
+			for (let i in item.creators) {
+				if (!item.creators[i].firstName){
+					item.creators[i].fieldMode=1;
+				}
+			}
+			for (let i = 0; i < item.attachments.length; i++) {
+				item.attachments[i].url = normalizeUrl(item.attachments[i].url);
+			}
+		}
+	}
+});
+
+/**Photos*/
+FW.Scraper({
+	itemType : 'artwork',
+	detect : FW.Xpath('//span[@class="description"]'),
+	title : FW.Xpath('//span[@class="description"]').text().trim(),
+	attachments : [{
+  	url : FW.Url(),
+  	title : "Wikimedia Snapshot",
+  	type : "text/html"
+	},
+	{
+		url : FW.Xpath('//div[@id="file"]/a/@href').text(),
+		title : "Wikimedia Image"
+	}],
+	creators : FW.Xpath('//tr/td[@id="fileinfotpl_aut"]/following-sibling::td').text().remove(/\n/g).remove(/\(.+/).cleanAuthor("author"),
+	date : FW.Xpath('//tr/td[@id="fileinfotpl_date"]/following-sibling::td').text(),
+	archive : FW.Xpath('//tr/td[@id="fileinfotpl_src"]/following-sibling::td').text(),
+	rights : FW.Xpath('//table[@class="licensetpl" or @class="layouttemplate licensetpl"]/tbody/tr/td[2]|//table[@class="licensetpl" or @class="layouttemplate licensetpl"]/tbody/tr/td/span').text(),
+	//fix authors w/o first names to single field mode
+	hooks : {
+  	"scraperDone": function  (item,doc, url) {
+			item.date = item.date ? item.date : item.runningTime;
+			item.runningTime = undefined;
+			for (let i in item.creators) {
+				if (!item.creators[i].firstName){
+					item.creators[i].fieldMode=1;
+				}
+			}
+			for (let i = 0; i < item.attachments.length; i++) {
+				item.attachments[i].url = normalizeUrl(item.attachments[i].url);
+			}
+		}
+	}
+});
+
+/** Search results */
+FW.MultiScraper({
+	itemType : "multiple",
+	detect : FW.Xpath('//ul[contains(@class, "search-results")]'),
+	choices : {
+		titles : FW.Xpath('//ul[contains(@class, "search-results")]//a[contains(@title, "File:")]').text(),
+		urls : FW.Xpath('//ul[contains(@class, "search-results")]//a[contains(@title, "File:")]').key('href').text()
+	}
+});
+
+/**Galleries */
+FW.MultiScraper({
+	itemType : "multiple",
+	detect : FW.Xpath('//ul[contains(@class, "gallery")]'),
+	choices : {
+  	titles : FW.Xpath('//ul[contains(@class, "gallery")]//div[@class="gallerytext"]').text(),
+  	urls : FW.Xpath('//ul[contains(@class, "gallery")]//a[@class="image"]').key('href').text()
+	}
+});
+/** BEGIN TEST CASES **/
+var testCases = [
+	{
+		"type": "web",
+		"url": "https://commons.wikimedia.org/wiki/File:Boy_with_a_Basket_of_Fruit-Caravaggio_(1593).jpg",
+		"items": [
+			{
+				"itemType": "artwork",
+				"title": "English: Boy with a Basket of Fruit",
+				"creators": [
+					{
+						"firstName": "",
+						"lastName": "Caravaggio",
+						"creatorType": "author",
+						"fieldMode": 1
+					}
+				],
+				"date": "circa 1593",
+				"archive": "Galleria Borghese",
+				"artworkMedium": "oil on canvas",
+				"artworkSize": "70 × 67 cm",
+				"libraryCatalog": "Wikimedia Commons",
+				"rights": "Public domain",
+				"shortTitle": "English",
+				"url": "https://commons.wikimedia.org/wiki/File:Boy_with_a_Basket_of_Fruit-Caravaggio_(1593).jpg",
+				"attachments": [
+					{
+						"title": "Wikimedia Snapshot",
+						"mimeType": "text/html"
+					},
+					{
+						"title": "Wikimedia Image"
+					}
+				],
+				"tags": [],
+				"notes": [],
+				"seeAlso": []
+			}
+		]
+	},
+	{
+		"type": "web",
+		"url": "http://commons.wikimedia.org/w/index.php?search=peron&button=&title=Special%3ASearch&limit=100",
+		"items": "multiple"
+	},
+	{
+		"type": "web",
+		"url": "https://commons.wikimedia.org/wiki/File:Portrait_of_Ambroise_Vollard.jpg",
+		"items": [
+			{
+				"itemType": "artwork",
+				"title": "English: Portrait of Ambroise Vollard",
+				"creators": [
+					{
+						"firstName": "Paul",
+						"lastName": "Cézanne",
+						"creatorType": "author"
+					}
+				],
+				"date": "1899",
+				"archive": "Petit Palais, Paris",
+				"artworkMedium": "oil on canvas",
+				"artworkSize": "101 × 81 cm (39.8 × 31.9 in)",
+				"libraryCatalog": "Wikimedia Commons",
+				"rights": "Public domain",
+				"shortTitle": "English",
+				"url": "https://commons.wikimedia.org/wiki/File:Portrait_of_Ambroise_Vollard.jpg",
+				"attachments": [
+					{
+						"title": "Wikimedia Snapshot",
+						"mimeType": "text/html"
+					},
+					{
+						"title": "Wikimedia Image"
+					}
+				],
+				"tags": [],
+				"notes": [],
+				"seeAlso": []
+			}
+		]
+	},
+	{
+		"type": "web",
+		"url": "https://commons.wikimedia.org/wiki/File:Plaza_Congreso.JPG",
+		"items": [
+			{
+				"itemType": "artwork",
+				"title": "English: Congressional Plaza, Buenos Aires, Argentina.",
+				"creators": [
+					{
+						"firstName": "",
+						"lastName": "Napoletano",
+						"creatorType": "author",
+						"fieldMode": 1
+					}
+				],
+				"date": "28 January 2012",
+				"archive": "Own work",
+				"libraryCatalog": "Wikimedia Commons",
+				"rights": "Permission is granted to copy, distribute and/or modify this document under the terms of the GNU Free Documentation License, Version 1.2 or any later version published by the Free Software Foundation; with no Invariant Sections, no Front-Cover Texts, and no Back-Cover Texts. A copy of the license is included in the section entitled GNU Free Documentation License.http://www.gnu.org/copyleft/fdl.htmlGFDLGNU Free Documentation Licensetruetrue",
+				"shortTitle": "English",
+				"url": "https://commons.wikimedia.org/wiki/File:Plaza_Congreso.JPG",
+				"attachments": [
+					{
+						"title": "Wikimedia Snapshot",
+						"mimeType": "text/html"
+					},
+					{
+						"title": "Wikimedia Image"
+					}
+				],
+				"tags": [],
+				"notes": [],
+				"seeAlso": []
+			}
+		]
+	},
+	{
+		"type": "web",
+		"url": "http://commons.wikimedia.org/wiki/Commons:Valued_images_by_topic/Science",
+		"items": "multiple"
+	},
+	{
+		"type": "web",
+		"url": "https://commons.wikimedia.org/wiki/File:NCL-9910006496_%E6%80%A7%E5%BF%83%E7%90%86%E5%AD%B8.pdf",
+		"items": "book"
+	},
+	{
+		"type": "web",
+		"url": "https://commons.wikimedia.org/w/index.php?search=%E5%BF%83%E7%90%86%E5%AD%B8+pdf&title=Special%3ASearch&profile=advanced&fulltext=1&ns0=1&ns6=1&ns12=1&ns14=1&ns100=1&ns106=1",
+		"items": "multiple"
+	}
+]
+/** END TEST CASES **/

--- a/Wikimedia Commons.js
+++ b/Wikimedia Commons.js
@@ -9,7 +9,7 @@
 	"inRepository": true,
 	"translatorType": 4,
 	"browserSupport": "gcsibv",
-	"lastUpdated": "2026-07-10 23:00:00"
+	"lastUpdated": "2026-07-10 21:30:06"
 }
 
 /*
@@ -144,7 +144,7 @@ function normalizeUrl(url) {
 
 function parseBookTemplate(wikitext) {
 	var params = {};
-	var match = wikitext.match(/\{\{\s*Book\s*([\s\S]*?)\n?\}\}/i);
+	var match = wikitext.match(/\{\{\s*Book\s*([\s\S]*?)\n\s*\}\}/i);
 	if (!match) return params;
 
 	var lines = match[1].split('\n');
@@ -165,7 +165,7 @@ function parseBookTemplate(wikitext) {
 
 function parseInformationTemplate(wikitext) {
 	var params = {};
-	var match = wikitext.match(/\{\{\s*Information\s*([\s\S]*?)\n?\}\}/i);
+	var match = wikitext.match(/\{\{\s*Information\s*([\s\S]*?)\n\s*\}\}/i);
 	if (!match) return params;
 
 	var lines = match[1].split('\n');
@@ -188,7 +188,8 @@ function cleanDescription(desc) {
 	if (!desc) return '';
 	desc = desc.replace(/\{\{\s*[a-z]{2,3}(?:-[a-zA-Z]+)?\s*\|\s*\d*\s*=\s*([^}]+)\}\}/g, '$1');
 	desc = desc.replace(/\{\{[^}]+\}\}/g, '');
-	return desc.trim();
+	var lines = desc.split('\n').map(function (l) { return l.trim(); }).filter(function (l) { return l; });
+	return lines.length ? lines[0] : '';
 }
 
 function cleanWikitextLink(text) {

--- a/Wikimedia Commons.js
+++ b/Wikimedia Commons.js
@@ -9,7 +9,7 @@
 	"inRepository": true,
 	"translatorType": 4,
 	"browserSupport": "gcsibv",
-	"lastUpdated": "2026-07-10 22:10:00"
+	"lastUpdated": "2026-07-10 23:00:00"
 }
 
 /*
@@ -163,6 +163,47 @@ function parseBookTemplate(wikitext) {
 	return params;
 }
 
+function parseInformationTemplate(wikitext) {
+	var params = {};
+	var match = wikitext.match(/\{\{\s*Information\s*([\s\S]*?)\n?\}\}/i);
+	if (!match) return params;
+
+	var lines = match[1].split('\n');
+	var currentKey = null;
+	for (var i = 0; i < lines.length; i++) {
+		var line = lines[i];
+		var paramMatch = line.match(/^\s*\|\s*([^\n=]+?)\s*=\s*(.*)$/);
+		if (paramMatch) {
+			currentKey = paramMatch[1].trim().toLowerCase();
+			params[currentKey] = paramMatch[2].trim();
+		}
+		else if (currentKey && line.trim() && !/^\s*\|/.test(line)) {
+			params[currentKey] += '\n' + line.trim();
+		}
+	}
+	return params;
+}
+
+function cleanDescription(desc) {
+	if (!desc) return '';
+	desc = desc.replace(/\{\{\s*[a-z]{2,3}(?:-[a-zA-Z]+)?\s*\|\s*\d*\s*=\s*([^}]+)\}\}/g, '$1');
+	desc = desc.replace(/\{\{[^}]+\}\}/g, '');
+	return desc.trim();
+}
+
+function cleanWikitextLink(text) {
+	if (!text) return '';
+	var linkMatch = text.match(/\[\[[^\]|]+\|([^\]]+)\]\]/);
+	if (linkMatch) return linkMatch[1].trim();
+	linkMatch = text.match(/\[\[([^\]]+)\]\]/);
+	if (linkMatch) return linkMatch[1].trim();
+	return text.trim();
+}
+
+function isChineseName(name) {
+	return /[\u4e00-\u9fa5]/.test(name);
+}
+
 function getInfoField(wikitext, fieldName) {
 	var regex = new RegExp('\\{\\{\\s*Information field\\s*\\|\\s*name\\s*=\\s*' + fieldName + '\\s*\\|\\s*value\\s*=\\s*([^}]+)\\}\\}', 'i');
 	var m = wikitext.match(regex);
@@ -200,13 +241,19 @@ function parseCreators(authorString, defaultType) {
 				name = name.replace(/^[\(（][^\)）]+[\)）]\s*/, '').trim();
 			}
 
-			if (name) {
+			if (!name) continue;
+
+			if (isChineseName(name)) {
 				creators.push({
 					firstName: '',
 					lastName: name,
 					creatorType: creatorType,
 					fieldMode: 1
 				});
+			}
+			else {
+				var cleaned = Zotero.Utilities.cleanAuthor(name, creatorType, false);
+				if (cleaned && cleaned.lastName) creators.push(cleaned);
 			}
 		}
 	}
@@ -239,33 +286,44 @@ function scrapeBook(doc, url, doneCallback) {
 		}
 
 		var wikitext = data && data.parse && data.parse.wikitext && data.parse.wikitext['*'] || '';
-		var params = parseBookTemplate(wikitext);
+		var bookParams = parseBookTemplate(wikitext);
+		var infoParams = parseInformationTemplate(wikitext);
 
 		var item = new Zotero.Item('book');
 		item.url = url;
 		item.libraryCatalog = 'Wikimedia Commons';
 
-		item.title = params.Title || textContent(doc, 'h1#firstHeading') || '';
-		item.title = item.title.replace(/^File:/, '').replace(BOOK_EXT_REGEX, '').trim();
+		var title = bookParams.Title;
+		if (!title && infoParams.description) title = cleanDescription(infoParams.description);
+		if (!title) title = textContent(doc, 'h1#firstHeading') || '';
+		item.title = title.replace(/^File:/, '').replace(BOOK_EXT_REGEX, '').trim();
 
-		addCreators(item, params.Author, 'author');
-		addCreators(item, params.Translator, 'author');
-		addCreators(item, params.Editor, 'author');
-		addCreators(item, params.Illustrator, 'author');
+		addCreators(item, bookParams.Author, 'author');
+		if (!item.creators.length && infoParams.author) {
+			addCreators(item, cleanWikitextLink(infoParams.author), 'author');
+		}
+		addCreators(item, bookParams.Translator, 'author');
+		addCreators(item, bookParams.Editor, 'author');
+		addCreators(item, bookParams.Illustrator, 'author');
 
-		if (params.Publisher) item.publisher = params.Publisher;
-		if (params['Publication date']) item.date = params['Publication date'];
-		if (params.City) item.place = params.City;
-		if (params.Edition) item.edition = params.Edition;
-		if (params.Language) item.language = mapLanguage(params.Language);
+		if (bookParams.Publisher) item.publisher = bookParams.Publisher;
+		if (bookParams['Publication date']) item.date = bookParams['Publication date'];
+		else if (infoParams.date) item.date = infoParams.date;
+		if (bookParams.City) item.place = bookParams.City;
+		if (bookParams.Edition) item.edition = bookParams.Edition;
+		if (bookParams.Language) item.language = mapLanguage(bookParams.Language);
+		else if (infoParams.description && /\{\{\s*en\s*\|/.test(infoParams.description)) item.language = 'en';
 
-		var pages = params.Pages || getInfoField(wikitext, 'Pages');
+		var pages = bookParams.Pages || getInfoField(wikitext, 'Pages');
 		if (pages) item.numPages = String(pages);
 
-		var source = params.Source;
+		var source = bookParams.Source;
 		if (source) {
 			source = source.replace(/\{\{[^}]+\}\}/g, '').trim();
 			item.archive = source;
+		}
+		else if (infoParams.source) {
+			item.archive = cleanWikitextLink(infoParams.source);
 		}
 
 		var attachMeta = getBookAttachmentMeta(filename);

--- a/Wikimedia Commons.js
+++ b/Wikimedia Commons.js
@@ -9,7 +9,7 @@
 	"inRepository": true,
 	"translatorType": 4,
 	"browserSupport": "gcsibv",
-	"lastUpdated": "2026-07-10 21:30:06"
+	"lastUpdated": "2022-12-06 00:15:52"
 }
 
 /*
@@ -36,359 +36,16 @@
 */
 
 // eslint-disable-next-line
-/* FW LINE 59:b820c6d */ function flatten(t){var e=new Array;for(var i in t){var r=t[i];r instanceof Array?e=e.concat(flatten(r)):e.push(r)}return e}var FW={_scrapers:new Array};FW._Base=function(){this.callHook=function(t,e,i,r){if("object"==typeof this.hooks){var n=this.hooks[t];"function"==typeof n&&n(e,i,r)}},this.evaluateThing=function(t,e,i){var r=typeof t;if("object"===r){if(t instanceof Array){var n=this.evaluateThing,a=t.map(function(t){return n(t,e,i)});return flatten(a)}return t.evaluate(e,i)}return"function"===r?t(e,i):t},this.makeItems=function(t,e,i,r,n){n()}},FW.Scraper=function(t){FW._scrapers.push(new FW._Scraper(t))},FW._Scraper=function(t){for(x in t)this[x]=t[x];this._singleFieldNames=["abstractNote","applicationNumber","archive","archiveLocation","artworkMedium","artworkSize","assignee","audioFileType","audioRecordingType","billNumber","blogTitle","bookTitle","callNumber","caseName","code","codeNumber","codePages","codeVolume","committee","company","conferenceName","country","court","date","dateDecided","dateEnacted","dictionaryTitle","distributor","docketNumber","documentNumber","DOI","edition","encyclopediaTitle","episodeNumber","extra","filingDate","firstPage","forumTitle","genre","history","institution","interviewMedium","ISBN","ISSN","issue","issueDate","issuingAuthority","journalAbbreviation","label","language","legalStatus","legislativeBody","letterType","libraryCatalog","manuscriptType","mapType","medium","meetingName","nameOfAct","network","number","numberOfVolumes","numPages","pages","patentNumber","place","postType","presentationType","priorityNumbers","proceedingsTitle","programTitle","programmingLanguage","publicLawNumber","publicationTitle","publisher","references","reportNumber","reportType","reporter","reporterVolume","rights","runningTime","scale","section","series","seriesNumber","seriesText","seriesTitle","session","shortTitle","studio","subject","system","thesisType","title","type","university","url","version","videoRecordingType","volume","websiteTitle","websiteType"],this._makeAttachments=function(t,e,i,r){if(i instanceof Array)i.forEach(function(i){this._makeAttachments(t,e,i,r)},this);else if("object"==typeof i){var n=i.urls||i.url,a=i.types||i.type,s=i.titles||i.title,o=i.snapshots||i.snapshot,u=this.evaluateThing(n,t,e),l=this.evaluateThing(s,t,e),c=this.evaluateThing(a,t,e),h=this.evaluateThing(o,t,e);u instanceof Array||(u=[u]);for(var f in u){var p,m,v,d=u[f];p=c instanceof Array?c[f]:c,m=l instanceof Array?l[f]:l,v=h instanceof Array?h[f]:h,r.attachments.push({url:d,title:m,mimeType:p,snapshot:v})}}},this.makeItems=function(t,e,i,r,n){var a=new Zotero.Item(this.itemType);a.url=e;for(var s in this._singleFieldNames){var o=this._singleFieldNames[s];if(this[o]){var u=this.evaluateThing(this[o],t,e);u instanceof Array?a[o]=u[0]:a[o]=u}}var l=["creators","tags"];for(var c in l){var h=l[c],f=this.evaluateThing(this[h],t,e);if(f)for(var p in f)a[h].push(f[p])}this._makeAttachments(t,e,this.attachments,a),r(a,this,t,e),n()}},FW._Scraper.prototype=new FW._Base,FW.MultiScraper=function(t){FW._scrapers.push(new FW._MultiScraper(t))},FW._MultiScraper=function(t){for(x in t)this[x]=t[x];this._mkSelectItems=function(t,e){var i=new Object;for(var r in t)i[e[r]]=t[r];return i},this._selectItems=function(t,e,i){var r=new Array;Zotero.selectItems(this._mkSelectItems(t,e),function(t){for(var e in t)r.push(e);i(r)})},this._mkAttachments=function(t,e,i){var r=this.evaluateThing(this.attachments,t,e),n=new Object;if(r)for(var a in i)n[i[a]]=r[a];return n},this._makeChoices=function(t,e,i,r,n){if(t instanceof Array)t.forEach(function(t){this._makeTitlesUrls(t,e,i,r,n)},this);else if("object"==typeof t){var a=t.urls||t.url,s=t.titles||t.title,o=this.evaluateThing(a,e,i),u=this.evaluateThing(s,e,i),l=u instanceof Array;o instanceof Array||(o=[o]);for(var c in o){var h,f=o[c];h=l?u[c]:u,n.push(f),r.push(h)}}},this.makeItems=function(t,e,i,r,n){if(this.beforeFilter){var a=this.beforeFilter(t,e);if(a!=e)return void this.makeItems(t,a,i,r,n)}var s=[],o=[];this._makeChoices(this.choices,t,e,s,o);var u=this._mkAttachments(t,e,o),l=this.itemTrans;this._selectItems(s,o,function(t){if(t){var e=function(t){var e=t.documentURI,i=l;void 0===i&&(i=FW.getScraper(t,e)),void 0===i||i.makeItems(t,e,u[e],r,function(){})};Zotero.Utilities.processDocuments(t,e,n)}else n()})}},FW._MultiScraper.prototype=new FW._Base,FW.WebDelegateTranslator=function(t){return new FW._WebDelegateTranslator(t)},FW._WebDelegateTranslator=function(t){for(x in t)this[x]=t[x];this.makeItems=function(t,e,i,r,n){var a=this,s=Zotero.loadTranslator("web");s.setHandler("itemDone",function(i,n){r(n,a,t,e)}),s.setDocument(t),this.translatorId?(s.setTranslator(this.translatorId),s.translate()):(s.setHandler("translators",function(t,e){e.length&&(s.setTranslator(e[0]),s.translate())}),s.getTranslators()),n()}},FW._WebDelegateTranslator.prototype=new FW._Base,FW._StringMagic=function(){this._filters=new Array,this.addFilter=function(t){return this._filters.push(t),this},this.split=function(t){return this.addFilter(function(e){return e.split(t).filter(function(t){return""!=t})})},this.replace=function(t,e,i){return this.addFilter(function(r){return"string"!=typeof r?r:r.match(t)?r.replace(t,e,i):r})},this.prepend=function(t){return this.replace(/^/,t)},this.append=function(t){return this.replace(/$/,t)},this.remove=function(t,e){return this.replace(t,"",e)},this.trim=function(){return this.addFilter(function(t){return Zotero.Utilities.trim(t)})},this.trimInternal=function(){return this.addFilter(function(t){return Zotero.Utilities.trimInternal(t)})},this.match=function(t,e){return e||(e=0),this.addFilter(function(i){var r=i.match(t);return void 0===r||null===r?void 0:r[e]})},this.cleanAuthor=function(t,e){return this.addFilter(function(i){return"string"!=typeof i?i:Zotero.Utilities.cleanAuthor(i,t,e)})},this.key=function(t){return this.addFilter(function(e){return e[t]})},this.capitalizeTitle=function(){return this.addFilter(function(t){return Zotero.Utilities.capitalizeTitle(t)})},this.unescapeHTML=function(){return this.addFilter(function(t){return Zotero.Utilities.unescapeHTML(t)})},this.unescape=function(){return this.addFilter(function(t){return unescape(t)})},this._applyFilters=function(t,e){for(i in this._filters){t=flatten(t),t=t.filter(function(t){return void 0!==t&&null!==t});for(var r=0;r<t.length;r++)try{if(void 0===t[r]||null===t[r])continue;t[r]=this._filters[i](t[r],e)}catch(n){t[r]=void 0,Zotero.debug("Caught exception "+n+"on filter: "+this._filters[i])}t=t.filter(function(t){return void 0!==t&&null!==t})}return flatten(t)}},FW.PageText=function(){return new FW._PageText},FW._PageText=function(){this._filters=new Array,this.evaluate=function(t){var e=[t.documentElement.innerHTML];return e=this._applyFilters(e,t),0==e.length?!1:e}},FW._PageText.prototype=new FW._StringMagic,FW.Url=function(){return new FW._Url},FW._Url=function(){this._filters=new Array,this.evaluate=function(t,e){var i=[e];return i=this._applyFilters(i,t),0==i.length?!1:i}},FW._Url.prototype=new FW._StringMagic,FW.Xpath=function(t){return new FW._Xpath(t)},FW._Xpath=function(t){this._xpath=t,this._filters=new Array,this.text=function(){var t=function(t){return"object"==typeof t&&t.textContent?t.textContent:t};return this.addFilter(t),this},this.sub=function(t){var e=function(e,i){var r=i.evaluate(t,e,null,XPathResult.ANY_TYPE,null);return r?r.iterateNext():void 0};return this.addFilter(e),this},this.evaluate=function(t){var e=t.evaluate(this._xpath,t,null,XPathResult.ANY_TYPE,null),i=e.resultType,r=new Array;if(i==XPathResult.STRING_TYPE)r.push(e.stringValue);else if(i==XPathResult.BOOLEAN_TYPE)r.push(e.booleanValue);else if(i==XPathResult.NUMBER_TYPE)r.push(e.numberValue);else if(i==XPathResult.ORDERED_NODE_ITERATOR_TYPE||i==XPathResult.UNORDERED_NODE_ITERATOR_TYPE)for(var n;n=e.iterateNext();)r.push(n);return r=this._applyFilters(r,t),0==r.length?!1:r}},FW._Xpath.prototype=new FW._StringMagic,FW.detectWeb=function(t,e){for(var i in FW._scrapers){var r=FW._scrapers[i],n=r.evaluateThing(r.itemType,t,e),a=r.evaluateThing(r.detect,t,e);if(a.length>0&&a[0])return n}},FW.getScraper=function(t,e){var i=FW.detectWeb(t,e);return FW._scrapers.filter(function(r){return r.evaluateThing(r.itemType,t,e)==i&&r.evaluateThing(r.detect,t,e)})[0]},FW.doWeb=function(t,e){var i=FW.getScraper(t,e);i.makeItems(t,e,[],function(t,e,i,r){e.callHook("scraperDone",t,i,r),t.title||(t.title=""),t.complete()},function(){Zotero.done()}),Zotero.wait()};
-var BOOK_EXT_REGEX = /\.(pdf|djvu|epub|mobi)$/i;
-
-function isBookPage(doc, url) {
-	return /\/wiki\/File:/.test(url) && BOOK_EXT_REGEX.test(url) &&
-		doc.querySelector('#fileinfotpl_book_publisher, #fileinfotpl_book_language, #fileinfotpl_art_title, #fileinfotpl_aut');
-}
-
-function isSearchResultsPage(doc, url) {
-	if (!/Special:Search/.test(url)) return false;
-	var params = parseUrlParams(url);
-	return !!(params.search && params.search.trim());
-}
-
-function parseUrlParams(url) {
-	var params = {};
-	var query = url.split('?')[1] || '';
-	if (!query) return params;
-	var parts = query.split('&');
-	for (var i = 0; i < parts.length; i++) {
-		var pair = parts[i].split('=');
-		if (pair.length < 2) continue;
-		var key = decodeURIComponent(pair[0]);
-		var value = decodeURIComponent(pair.slice(1).join('=').replace(/\+/g, ' '));
-		params[key] = value;
-	}
-	return params;
-}
-
-function getSearchResults(url, callback) {
-	var params = parseUrlParams(url);
-	var searchTerm = params.search;
-	if (!searchTerm) {
-		callback({});
-		return;
-	}
-
-	var namespaces = [];
-	for (var key in params) {
-		var m = key.match(/^ns(\d+)$/);
-		if (m && params[key] === '1') namespaces.push(m[1]);
-	}
-	var ns = namespaces.length ? namespaces.join('|') : '6';
-	var apiUrl = 'https://commons.wikimedia.org/w/api.php?action=query&list=search&srsearch='
-		+ encodeURIComponent(searchTerm)
-		+ '&srnamespace=' + ns
-		+ '&srlimit=50&format=json';
-
-	ZU.doGet(apiUrl, function (respText) {
-		var data;
-		try {
-			data = JSON.parse(respText);
-		}
-		catch (e) {
-			Zotero.debug('Wikimedia Commons: failed to parse search API response: ' + e);
-		}
-
-		var items = {};
-		var results = data && data.query && data.query.search || [];
-		for (var i = 0; i < results.length; i++) {
-			var title = results[i].title;
-			if (!title || !/^File:/i.test(title)) continue;
-			if (!BOOK_EXT_REGEX.test(title)) continue;
-			var pageTitle = title.replace(/ /g, '_');
-			var itemUrl = 'https://commons.wikimedia.org/wiki/' + encodeURIComponent(pageTitle).replace(/%2F/g, '/');
-			var display = title.replace(/^File:/i, '').replace(/_/g, ' ');
-			items[itemUrl] = display;
-		}
-		callback(items);
-	});
-}
-
-function getFilenameFromUrl(url) {
-	var decoded = decodeURIComponent(url);
-	var match = decoded.match(/\/wiki\/File:([^#?]+)/);
-	return match ? match[1] : '';
-}
-
-function getBookAttachmentMeta(filename) {
-	var extMatch = filename.match(/\.([^.]+)$/);
-	var ext = extMatch ? extMatch[1].toLowerCase() : '';
-	var mimeType = 'application/octet-stream';
-	if (ext === 'pdf') mimeType = 'application/pdf';
-	else if (ext === 'djvu') mimeType = 'image/vnd.djvu';
-	else if (ext === 'epub') mimeType = 'application/epub+zip';
-	else if (ext === 'mobi') mimeType = 'application/x-mobipocket-ebook';
-	return {
-		ext: ext,
-		title: ext ? 'Wikimedia Commons ' + ext.toUpperCase() : 'Wikimedia Commons File',
-		mimeType: mimeType
-	};
-}
-
-function textContent(doc, selector) {
-	var el = doc.querySelector(selector);
-	return el ? el.textContent : '';
-}
-
-function normalizeUrl(url) {
-	if (!url || typeof url !== 'string') return url;
-	if (/^https?:\/\//.test(url)) return url;
-	if (/^\/\//.test(url)) return 'https:' + url;
-	if (/^\//.test(url)) return 'https://commons.wikimedia.org' + url;
-	return url;
-}
-
-function parseBookTemplate(wikitext) {
-	var params = {};
-	var match = wikitext.match(/\{\{\s*Book\s*([\s\S]*?)\n\s*\}\}/i);
-	if (!match) return params;
-
-	var lines = match[1].split('\n');
-	var currentKey = null;
-	for (var i = 0; i < lines.length; i++) {
-		var line = lines[i];
-		var paramMatch = line.match(/^\s*\|\s*([^\n=]+?)\s*=\s*(.*)$/);
-		if (paramMatch) {
-			currentKey = paramMatch[1].trim();
-			params[currentKey] = paramMatch[2].trim();
-		}
-		else if (currentKey && line.trim() && !/^\s*\|/.test(line)) {
-			params[currentKey] += '\n' + line.trim();
-		}
-	}
-	return params;
-}
-
-function parseInformationTemplate(wikitext) {
-	var params = {};
-	var match = wikitext.match(/\{\{\s*Information\s*([\s\S]*?)\n\s*\}\}/i);
-	if (!match) return params;
-
-	var lines = match[1].split('\n');
-	var currentKey = null;
-	for (var i = 0; i < lines.length; i++) {
-		var line = lines[i];
-		var paramMatch = line.match(/^\s*\|\s*([^\n=]+?)\s*=\s*(.*)$/);
-		if (paramMatch) {
-			currentKey = paramMatch[1].trim().toLowerCase();
-			params[currentKey] = paramMatch[2].trim();
-		}
-		else if (currentKey && line.trim() && !/^\s*\|/.test(line)) {
-			params[currentKey] += '\n' + line.trim();
-		}
-	}
-	return params;
-}
-
-function cleanDescription(desc) {
-	if (!desc) return '';
-	desc = desc.replace(/\{\{\s*[a-z]{2,3}(?:-[a-zA-Z]+)?\s*\|\s*\d*\s*=\s*([^}]+)\}\}/g, '$1');
-	desc = desc.replace(/\{\{[^}]+\}\}/g, '');
-	var lines = desc.split('\n').map(function (l) { return l.trim(); }).filter(function (l) { return l; });
-	return lines.length ? lines[0] : '';
-}
-
-function cleanWikitextLink(text) {
-	if (!text) return '';
-	var linkMatch = text.match(/\[\[[^\]|]+\|([^\]]+)\]\]/);
-	if (linkMatch) return linkMatch[1].trim();
-	linkMatch = text.match(/\[\[([^\]]+)\]\]/);
-	if (linkMatch) return linkMatch[1].trim();
-	return text.trim();
-}
-
-function isChineseName(name) {
-	return /[\u4e00-\u9fa5]/.test(name);
-}
-
-function getInfoField(wikitext, fieldName) {
-	var regex = new RegExp('\\{\\{\\s*Information field\\s*\\|\\s*name\\s*=\\s*' + fieldName + '\\s*\\|\\s*value\\s*=\\s*([^}]+)\\}\\}', 'i');
-	var m = wikitext.match(regex);
-	return m ? m[1].trim() : null;
-}
-
-function addCreators(item, value, defaultType) {
-	if (!value) return;
-	var creators = parseCreators(value, defaultType);
-	for (var i = 0; i < creators.length; i++) {
-		item.creators.push(creators[i]);
-	}
-}
-
-function parseCreators(authorString, defaultType) {
-	var creators = [];
-	var segments = authorString.split(/[；;]/);
-	for (var s = 0; s < segments.length; s++) {
-		var segment = segments[s].trim();
-		if (!segment) continue;
-
-		var creatorType = defaultType || 'author';
-
-		var cleaned = segment.replace(/(原著|著译|著譯|著|译|譯|翻|编译|編|编|撰|[註注]|整理|校订|校訂|主編|主编)/g, '').trim();
-		var names = cleaned.split(/[，,]/);
-		for (var i = 0; i < names.length; i++) {
-			var name = names[i].trim();
-			if (!name) continue;
-
-			var parenMatch = name.match(/^([^\(（]+)[\(（]/);
-			if (parenMatch && parenMatch[1].trim()) {
-				name = parenMatch[1].trim();
-			}
-			else if (/^[\(（]/.test(name)) {
-				name = name.replace(/^[\(（][^\)）]+[\)）]\s*/, '').trim();
-			}
-
-			if (!name) continue;
-
-			if (isChineseName(name)) {
-				creators.push({
-					firstName: '',
-					lastName: name,
-					creatorType: creatorType,
-					fieldMode: 1
-				});
-			}
-			else {
-				var cleaned = Zotero.Utilities.cleanAuthor(name, creatorType, false);
-				if (cleaned && cleaned.lastName) creators.push(cleaned);
-			}
-		}
-	}
-	return creators;
-}
-
-function mapLanguage(lang) {
-	if (!lang) return '';
-	lang = lang.toLowerCase();
-	if (lang === 'zh' || lang === 'chinese' || lang === '中文') return 'zh';
-	if (lang === 'zh-tw') return 'zh-TW';
-	if (lang === 'zh-cn') return 'zh-CN';
-	if (lang === 'en' || lang === 'english') return 'en';
-	return lang;
-}
-
-function scrapeBook(doc, url, doneCallback) {
-	var filename = getFilenameFromUrl(url);
-	var filePathUrl = 'https://commons.wikimedia.org/wiki/Special:FilePath/' + encodeURIComponent(filename);
-	var apiUrl = 'https://commons.wikimedia.org/w/api.php?action=parse&page=File:'
-		+ encodeURIComponent(filename) + '&prop=wikitext&format=json';
-
-	ZU.doGet(apiUrl, function (respText) {
-		var data;
-		try {
-			data = JSON.parse(respText);
-		}
-		catch (e) {
-			Zotero.debug('Wikimedia Commons: failed to parse API response: ' + e);
-		}
-
-		var wikitext = data && data.parse && data.parse.wikitext && data.parse.wikitext['*'] || '';
-		var bookParams = parseBookTemplate(wikitext);
-		var infoParams = parseInformationTemplate(wikitext);
-
-		var item = new Zotero.Item('book');
-		item.url = url;
-		item.libraryCatalog = 'Wikimedia Commons';
-
-		var title = bookParams.Title;
-		if (!title && infoParams.description) title = cleanDescription(infoParams.description);
-		if (!title) title = textContent(doc, 'h1#firstHeading') || '';
-		item.title = title.replace(/^File:/, '').replace(BOOK_EXT_REGEX, '').trim();
-
-		addCreators(item, bookParams.Author, 'author');
-		if (!item.creators.length && infoParams.author) {
-			addCreators(item, cleanWikitextLink(infoParams.author), 'author');
-		}
-		addCreators(item, bookParams.Translator, 'author');
-		addCreators(item, bookParams.Editor, 'author');
-		addCreators(item, bookParams.Illustrator, 'author');
-
-		if (bookParams.Publisher) item.publisher = bookParams.Publisher;
-		if (bookParams['Publication date']) item.date = bookParams['Publication date'];
-		else if (infoParams.date) item.date = infoParams.date;
-		if (bookParams.City) item.place = bookParams.City;
-		if (bookParams.Edition) item.edition = bookParams.Edition;
-		if (bookParams.Language) item.language = mapLanguage(bookParams.Language);
-		else if (infoParams.description && /\{\{\s*en\s*\|/.test(infoParams.description)) item.language = 'en';
-
-		var pages = bookParams.Pages || getInfoField(wikitext, 'Pages');
-		if (pages) item.numPages = String(pages);
-
-		var source = bookParams.Source;
-		if (source) {
-			source = source.replace(/\{\{[^}]+\}\}/g, '').trim();
-			item.archive = source;
-		}
-		else if (infoParams.source) {
-			item.archive = cleanWikitextLink(infoParams.source);
-		}
-
-		var attachMeta = getBookAttachmentMeta(filename);
-		item.attachments.push({
-			title: attachMeta.title,
-			url: filePathUrl,
-			mimeType: attachMeta.mimeType
-		});
-		item.attachments.push({
-			title: 'Wikimedia Commons Snapshot',
-			url: url,
-			mimeType: 'text/html',
-			snapshot: false
-		});
-
-		item.complete();
-		if (typeof doneCallback === 'function') doneCallback();
-	});
-}
-
-function detectWeb(doc, url) {
+/* FW LINE 59:b820c6d */ function flatten(t){var e=new Array;for(var i in t){var r=t[i];r instanceof Array?e=e.concat(flatten(r)):e.push(r)}return e}var FW={_scrapers:new Array};FW._Base=function(){this.callHook=function(t,e,i,r){if("object"==typeof this.hooks){var n=this.hooks[t];"function"==typeof n&&n(e,i,r)}},this.evaluateThing=function(t,e,i){var r=typeof t;if("object"===r){if(t instanceof Array){var n=this.evaluateThing,a=t.map(function(t){return n(t,e,i)});return flatten(a)}return t.evaluate(e,i)}return"function"===r?t(e,i):t},this.makeItems=function(t,e,i,r,n){n()}},FW.Scraper=function(t){FW._scrapers.push(new FW._Scraper(t))},FW._Scraper=function(t){for(x in t)this[x]=t[x];this._singleFieldNames=["abstractNote","applicationNumber","archive","archiveLocation","artworkMedium","artworkSize","assignee","audioFileType","audioRecordingType","billNumber","blogTitle","bookTitle","callNumber","caseName","code","codeNumber","codePages","codeVolume","committee","company","conferenceName","country","court","date","dateDecided","dateEnacted","dictionaryTitle","distributor","docketNumber","documentNumber","DOI","edition","encyclopediaTitle","episodeNumber","extra","filingDate","firstPage","forumTitle","genre","history","institution","interviewMedium","ISBN","ISSN","issue","issueDate","issuingAuthority","journalAbbreviation","label","language","legalStatus","legislativeBody","letterType","libraryCatalog","manuscriptType","mapType","medium","meetingName","nameOfAct","network","number","numberOfVolumes","numPages","pages","patentNumber","place","postType","presentationType","priorityNumbers","proceedingsTitle","programTitle","programmingLanguage","publicLawNumber","publicationTitle","publisher","references","reportNumber","reportType","reporter","reporterVolume","rights","runningTime","scale","section","series","seriesNumber","seriesText","seriesTitle","session","shortTitle","studio","subject","system","thesisType","title","type","university","url","version","videoRecordingType","volume","websiteTitle","websiteType"],this._makeAttachments=function(t,e,i,r){if(i instanceof Array)i.forEach(function(i){this._makeAttachments(t,e,i,r)},this);else if("object"==typeof i){var n=i.urls||i.url,a=i.types||i.type,s=i.titles||i.title,o=i.snapshots||i.snapshot,u=this.evaluateThing(n,t,e),l=this.evaluateThing(s,t,e),c=this.evaluateThing(a,t,e),h=this.evaluateThing(o,t,e);u instanceof Array||(u=[u]);for(var f in u){var p,m,v,d=u[f];p=c instanceof Array?c[f]:c,m=l instanceof Array?l[f]:l,v=h instanceof Array?h[f]:h,r.attachments.push({url:d,title:m,mimeType:p,snapshot:v})}}},this.makeItems=function(t,e,i,r,n){var a=new Zotero.Item(this.itemType);a.url=e;for(var s in this._singleFieldNames){var o=this._singleFieldNames[s];if(this[o]){var u=this.evaluateThing(this[o],t,e);u instanceof Array?a[o]=u[0]:a[o]=u}}var l=["creators","tags"];for(var c in l){var h=l[c],f=this.evaluateThing(this[h],t,e);if(f)for(var p in f)a[h].push(f[p])}this._makeAttachments(t,e,this.attachments,a),r(a,this,t,e),n()}},FW._Scraper.prototype=new FW._Base,FW.MultiScraper=function(t){FW._scrapers.push(new FW._MultiScraper(t))},FW._MultiScraper=function(t){for(x in t)this[x]=t[x];this._mkSelectItems=function(t,e){var i=new Object;for(var r in t)i[e[r]]=t[r];return i},this._selectItems=function(t,e,i){var r=new Array;Zotero.selectItems(this._mkSelectItems(t,e),function(t){for(var e in t)r.push(e);i(r)})},this._mkAttachments=function(t,e,i){var r=this.evaluateThing(this.attachments,t,e),n=new Object;if(r)for(var a in i)n[i[a]]=r[a];return n},this._makeChoices=function(t,e,i,r,n){if(t instanceof Array)t.forEach(function(t){this._makeTitlesUrls(t,e,i,r,n)},this);else if("object"==typeof t){var a=t.urls||t.url,s=t.titles||t.title,o=this.evaluateThing(a,e,i),u=this.evaluateThing(s,e,i),l=u instanceof Array;o instanceof Array||(o=[o]);for(var c in o){var h,f=o[c];h=l?u[c]:u,n.push(f),r.push(h)}}},this.makeItems=function(t,e,i,r,n){if(this.beforeFilter){var a=this.beforeFilter(t,e);if(a!=e)return void this.makeItems(t,a,i,r,n)}var s=[],o=[];this._makeChoices(this.choices,t,e,s,o);var u=this._mkAttachments(t,e,o),l=this.itemTrans;this._selectItems(s,o,function(t){if(t){var e=function(t){var e=t.documentURI,i=l;void 0===i&&(i=FW.getScraper(t,e)),void 0===i||i.makeItems(t,e,u[e],r,function(){})};Zotero.Utilities.processDocuments(t,e,n)}else n()})}},FW._MultiScraper.prototype=new FW._Base,FW.WebDelegateTranslator=function(t){return new FW._WebDelegateTranslator(t)},FW._WebDelegateTranslator=function(t){for(x in t)this[x]=t[x];this.makeItems=function(t,e,i,r,n){var a=this,s=Zotero.loadTranslator("web");s.setHandler("itemDone",function(i,n){r(n,a,t,e)}),s.setDocument(t),this.translatorId?(s.setTranslator(this.translatorId),s.translate()):(s.setHandler("translators",function(t,e){e.length&&(s.setTranslator(e[0]),s.translate())}),s.getTranslators()),n()}},FW._WebDelegateTranslator.prototype=new FW._Base,FW._StringMagic=function(){this._filters=new Array,this.addFilter=function(t){return this._filters.push(t),this},this.split=function(t){return this.addFilter(function(e){return e.split(t).filter(function(t){return""!=t})})},this.replace=function(t,e,i){return this.addFilter(function(r){return r.match(t)?r.replace(t,e,i):r})},this.prepend=function(t){return this.replace(/^/,t)},this.append=function(t){return this.replace(/$/,t)},this.remove=function(t,e){return this.replace(t,"",e)},this.trim=function(){return this.addFilter(function(t){return Zotero.Utilities.trim(t)})},this.trimInternal=function(){return this.addFilter(function(t){return Zotero.Utilities.trimInternal(t)})},this.match=function(t,e){return e||(e=0),this.addFilter(function(i){var r=i.match(t);return void 0===r||null===r?void 0:r[e]})},this.cleanAuthor=function(t,e){return this.addFilter(function(i){return Zotero.Utilities.cleanAuthor(i,t,e)})},this.key=function(t){return this.addFilter(function(e){return e[t]})},this.capitalizeTitle=function(){return this.addFilter(function(t){return Zotero.Utilities.capitalizeTitle(t)})},this.unescapeHTML=function(){return this.addFilter(function(t){return Zotero.Utilities.unescapeHTML(t)})},this.unescape=function(){return this.addFilter(function(t){return unescape(t)})},this._applyFilters=function(t,e){for(i in this._filters){t=flatten(t),t=t.filter(function(t){return void 0!==t&&null!==t});for(var r=0;r<t.length;r++)try{if(void 0===t[r]||null===t[r])continue;t[r]=this._filters[i](t[r],e)}catch(n){t[r]=void 0,Zotero.debug("Caught exception "+n+"on filter: "+this._filters[i])}t=t.filter(function(t){return void 0!==t&&null!==t})}return flatten(t)}},FW.PageText=function(){return new FW._PageText},FW._PageText=function(){this._filters=new Array,this.evaluate=function(t){var e=[t.documentElement.innerHTML];return e=this._applyFilters(e,t),0==e.length?!1:e}},FW._PageText.prototype=new FW._StringMagic,FW.Url=function(){return new FW._Url},FW._Url=function(){this._filters=new Array,this.evaluate=function(t,e){var i=[e];return i=this._applyFilters(i,t),0==i.length?!1:i}},FW._Url.prototype=new FW._StringMagic,FW.Xpath=function(t){return new FW._Xpath(t)},FW._Xpath=function(t){this._xpath=t,this._filters=new Array,this.text=function(){var t=function(t){return"object"==typeof t&&t.textContent?t.textContent:t};return this.addFilter(t),this},this.sub=function(t){var e=function(e,i){var r=i.evaluate(t,e,null,XPathResult.ANY_TYPE,null);return r?r.iterateNext():void 0};return this.addFilter(e),this},this.evaluate=function(t){var e=t.evaluate(this._xpath,t,null,XPathResult.ANY_TYPE,null),i=e.resultType,r=new Array;if(i==XPathResult.STRING_TYPE)r.push(e.stringValue);else if(i==XPathResult.BOOLEAN_TYPE)r.push(e.booleanValue);else if(i==XPathResult.NUMBER_TYPE)r.push(e.numberValue);else if(i==XPathResult.ORDERED_NODE_ITERATOR_TYPE||i==XPathResult.UNORDERED_NODE_ITERATOR_TYPE)for(var n;n=e.iterateNext();)r.push(n);return r=this._applyFilters(r,t),0==r.length?!1:r}},FW._Xpath.prototype=new FW._StringMagic,FW.detectWeb=function(t,e){for(var i in FW._scrapers){var r=FW._scrapers[i],n=r.evaluateThing(r.itemType,t,e),a=r.evaluateThing(r.detect,t,e);if(a.length>0&&a[0])return n}},FW.getScraper=function(t,e){var i=FW.detectWeb(t,e);return FW._scrapers.filter(function(r){return r.evaluateThing(r.itemType,t,e)==i&&r.evaluateThing(r.detect,t,e)})[0]},FW.doWeb=function(t,e){var i=FW.getScraper(t,e);i.makeItems(t,e,[],function(t,e,i,r){e.callHook("scraperDone",t,i,r),t.title||(t.title=""),t.complete()},function(){Zotero.done()}),Zotero.wait()};
+function detectWeb(doc, url) { 
 	// Diff interface is not supported
 	if (new URLSearchParams(doc.location.search).get('diff')) {
 		return false;
 	}
-
-	if (isBookPage(doc, url)) return 'book';
-	if (isSearchResultsPage(doc, url)) return 'multiple';
+	
 	return FW.detectWeb(doc, url);
 }
-
-function doWeb(doc, url) {
-	var itemType = detectWeb(doc, url);
-	if (itemType === 'book') {
-		scrapeBook(doc, url, function () { Zotero.done(); });
-		Zotero.wait();
-	}
-	else if (itemType === 'multiple') {
-		getSearchResults(url, function (items) {
-			if (!items || Object.keys(items).length === 0) {
-				Zotero.done();
-				return;
-			}
-			Zotero.selectItems(items, function (selected) {
-				if (!selected) {
-					Zotero.done();
-					return;
-				}
-				var urls = Object.keys(selected);
-				var completed = 0;
-				ZU.processDocuments(urls, function (newDoc, newUrl) {
-					scrapeBook(newDoc, newUrl, function () {
-						completed++;
-						if (completed >= urls.length) Zotero.done();
-					});
-				});
-			});
-		});
-		Zotero.wait();
-	}
-	else {
-		return FW.doWeb(doc, url);
-	}
-}
+function doWeb(doc, url) { return FW.doWeb(doc, url); }
 
 /*
 	***** BEGIN LICENSE BLOCK *****
@@ -420,13 +77,9 @@ FW.Scraper({
 	itemType : 'artwork',
 	detect : FW.Xpath('//td[@id="fileinfotpl_art_title" or @id="fileinfotpl_desc"]'),
 	title : FW.Xpath('//td[@id="fileinfotpl_art_title" or @id="fileinfotpl_desc"]/following-sibling::td').text().trim().remove(/\n.+/g),
-	attachments : [{
-  	url : FW.Url(),
-  	title : "Wikimedia Snapshot",
-  	type : "text/html"
-	},
+	attachments : [
 	{
-		url : FW.Xpath('//div[@id="file"]/a/@href').text(),
+		url : FW.Xpath('//div[@id="file"]/a/@href').text().prepend("http:"),
 		title : "Wikimedia Image"
 	}],
 	creators : FW.Xpath('//tr/td[@id="fileinfotpl_aut"]/following-sibling::td').text().remove(/\n/g).remove(/\(.+/).cleanAuthor("author"),
@@ -446,9 +99,6 @@ FW.Scraper({
 					item.creators[i].fieldMode=1;
 				}
 			}
-			for (let i = 0; i < item.attachments.length; i++) {
-				item.attachments[i].url = normalizeUrl(item.attachments[i].url);
-			}
 		}
 	}
 });
@@ -458,13 +108,9 @@ FW.Scraper({
 	itemType : 'artwork',
 	detect : FW.Xpath('//span[@class="description"]'),
 	title : FW.Xpath('//span[@class="description"]').text().trim(),
-	attachments : [{
-  	url : FW.Url(),
-  	title : "Wikimedia Snapshot",
-  	type : "text/html"
-	},
+	attachments : [
 	{
-		url : FW.Xpath('//div[@id="file"]/a/@href').text(),
+		url : FW.Xpath('//div[@id="file"]/a/@href').text().prepend("http:"),
 		title : "Wikimedia Image"
 	}],
 	creators : FW.Xpath('//tr/td[@id="fileinfotpl_aut"]/following-sibling::td').text().remove(/\n/g).remove(/\(.+/).cleanAuthor("author"),
@@ -480,9 +126,6 @@ FW.Scraper({
 				if (!item.creators[i].firstName){
 					item.creators[i].fieldMode=1;
 				}
-			}
-			for (let i = 0; i < item.attachments.length; i++) {
-				item.attachments[i].url = normalizeUrl(item.attachments[i].url);
 			}
 		}
 	}
@@ -532,15 +175,11 @@ var testCases = [
 				"rights": "Public domain",
 				"shortTitle": "English",
 				"url": "https://commons.wikimedia.org/wiki/File:Boy_with_a_Basket_of_Fruit-Caravaggio_(1593).jpg",
-				"attachments": [
-					{
-						"title": "Wikimedia Snapshot",
-						"mimeType": "text/html"
-					},
-					{
-						"title": "Wikimedia Image"
-					}
-				],
+			"attachments": [
+				{
+					"title": "Wikimedia Image"
+				}
+			],
 				"tags": [],
 				"notes": [],
 				"seeAlso": []
@@ -574,15 +213,11 @@ var testCases = [
 				"rights": "Public domain",
 				"shortTitle": "English",
 				"url": "https://commons.wikimedia.org/wiki/File:Portrait_of_Ambroise_Vollard.jpg",
-				"attachments": [
-					{
-						"title": "Wikimedia Snapshot",
-						"mimeType": "text/html"
-					},
-					{
-						"title": "Wikimedia Image"
-					}
-				],
+			"attachments": [
+				{
+					"title": "Wikimedia Image"
+				}
+			],
 				"tags": [],
 				"notes": [],
 				"seeAlso": []
@@ -611,14 +246,10 @@ var testCases = [
 				"shortTitle": "English",
 				"url": "https://commons.wikimedia.org/wiki/File:Plaza_Congreso.JPG",
 				"attachments": [
-					{
-						"title": "Wikimedia Snapshot",
-						"mimeType": "text/html"
-					},
-					{
-						"title": "Wikimedia Image"
-					}
-				],
+				{
+					"title": "Wikimedia Image"
+				}
+			],
 				"tags": [],
 				"notes": [],
 				"seeAlso": []
@@ -628,16 +259,6 @@ var testCases = [
 	{
 		"type": "web",
 		"url": "http://commons.wikimedia.org/wiki/Commons:Valued_images_by_topic/Science",
-		"items": "multiple"
-	},
-	{
-		"type": "web",
-		"url": "https://commons.wikimedia.org/wiki/File:NCL-9910006496_%E6%80%A7%E5%BF%83%E7%90%86%E5%AD%B8.pdf",
-		"items": "book"
-	},
-	{
-		"type": "web",
-		"url": "https://commons.wikimedia.org/w/index.php?search=%E5%BF%83%E7%90%86%E5%AD%B8+pdf&title=Special%3ASearch&profile=advanced&fulltext=1&ns0=1&ns6=1&ns12=1&ns14=1&ns100=1&ns106=1",
 		"items": "multiple"
 	}
 ]

--- a/Wikimedia Commons.js
+++ b/Wikimedia Commons.js
@@ -1,21 +1,21 @@
 {
-	"translatorID": "c70055c3-a525-45db-8e37-726c6c2ad034",
+	"translatorID": "07b2cafc-f7d0-4943-8eda-1afc99b1d2ad",
 	"label": "Wikimedia Commons",
-	"creator": "Sebastian Karcher",
+	"creator": "Daxoel",
 	"target": "^https?://commons\\.wikimedia\\.org",
-	"minVersion": "2.1.9",
+	"minVersion": "5.0",
 	"maxVersion": "",
 	"priority": 100,
 	"inRepository": true,
 	"translatorType": 4,
 	"browserSupport": "gcsibv",
-	"lastUpdated": "2022-12-06 00:15:52"
+	"lastUpdated": "2026-08-18 20:00:00"
 }
 
 /*
 	***** BEGIN LICENSE BLOCK *****
 
-	Copyright © 2014-2019 Sebastian Karcher
+	Copyright © 2026 4965898
 
 	This file is part of Zotero.
 
@@ -35,121 +35,775 @@
 	***** END LICENSE BLOCK *****
 */
 
-// eslint-disable-next-line
-/* FW LINE 59:b820c6d */ function flatten(t){var e=new Array;for(var i in t){var r=t[i];r instanceof Array?e=e.concat(flatten(r)):e.push(r)}return e}var FW={_scrapers:new Array};FW._Base=function(){this.callHook=function(t,e,i,r){if("object"==typeof this.hooks){var n=this.hooks[t];"function"==typeof n&&n(e,i,r)}},this.evaluateThing=function(t,e,i){var r=typeof t;if("object"===r){if(t instanceof Array){var n=this.evaluateThing,a=t.map(function(t){return n(t,e,i)});return flatten(a)}return t.evaluate(e,i)}return"function"===r?t(e,i):t},this.makeItems=function(t,e,i,r,n){n()}},FW.Scraper=function(t){FW._scrapers.push(new FW._Scraper(t))},FW._Scraper=function(t){for(x in t)this[x]=t[x];this._singleFieldNames=["abstractNote","applicationNumber","archive","archiveLocation","artworkMedium","artworkSize","assignee","audioFileType","audioRecordingType","billNumber","blogTitle","bookTitle","callNumber","caseName","code","codeNumber","codePages","codeVolume","committee","company","conferenceName","country","court","date","dateDecided","dateEnacted","dictionaryTitle","distributor","docketNumber","documentNumber","DOI","edition","encyclopediaTitle","episodeNumber","extra","filingDate","firstPage","forumTitle","genre","history","institution","interviewMedium","ISBN","ISSN","issue","issueDate","issuingAuthority","journalAbbreviation","label","language","legalStatus","legislativeBody","letterType","libraryCatalog","manuscriptType","mapType","medium","meetingName","nameOfAct","network","number","numberOfVolumes","numPages","pages","patentNumber","place","postType","presentationType","priorityNumbers","proceedingsTitle","programTitle","programmingLanguage","publicLawNumber","publicationTitle","publisher","references","reportNumber","reportType","reporter","reporterVolume","rights","runningTime","scale","section","series","seriesNumber","seriesText","seriesTitle","session","shortTitle","studio","subject","system","thesisType","title","type","university","url","version","videoRecordingType","volume","websiteTitle","websiteType"],this._makeAttachments=function(t,e,i,r){if(i instanceof Array)i.forEach(function(i){this._makeAttachments(t,e,i,r)},this);else if("object"==typeof i){var n=i.urls||i.url,a=i.types||i.type,s=i.titles||i.title,o=i.snapshots||i.snapshot,u=this.evaluateThing(n,t,e),l=this.evaluateThing(s,t,e),c=this.evaluateThing(a,t,e),h=this.evaluateThing(o,t,e);u instanceof Array||(u=[u]);for(var f in u){var p,m,v,d=u[f];p=c instanceof Array?c[f]:c,m=l instanceof Array?l[f]:l,v=h instanceof Array?h[f]:h,r.attachments.push({url:d,title:m,mimeType:p,snapshot:v})}}},this.makeItems=function(t,e,i,r,n){var a=new Zotero.Item(this.itemType);a.url=e;for(var s in this._singleFieldNames){var o=this._singleFieldNames[s];if(this[o]){var u=this.evaluateThing(this[o],t,e);u instanceof Array?a[o]=u[0]:a[o]=u}}var l=["creators","tags"];for(var c in l){var h=l[c],f=this.evaluateThing(this[h],t,e);if(f)for(var p in f)a[h].push(f[p])}this._makeAttachments(t,e,this.attachments,a),r(a,this,t,e),n()}},FW._Scraper.prototype=new FW._Base,FW.MultiScraper=function(t){FW._scrapers.push(new FW._MultiScraper(t))},FW._MultiScraper=function(t){for(x in t)this[x]=t[x];this._mkSelectItems=function(t,e){var i=new Object;for(var r in t)i[e[r]]=t[r];return i},this._selectItems=function(t,e,i){var r=new Array;Zotero.selectItems(this._mkSelectItems(t,e),function(t){for(var e in t)r.push(e);i(r)})},this._mkAttachments=function(t,e,i){var r=this.evaluateThing(this.attachments,t,e),n=new Object;if(r)for(var a in i)n[i[a]]=r[a];return n},this._makeChoices=function(t,e,i,r,n){if(t instanceof Array)t.forEach(function(t){this._makeTitlesUrls(t,e,i,r,n)},this);else if("object"==typeof t){var a=t.urls||t.url,s=t.titles||t.title,o=this.evaluateThing(a,e,i),u=this.evaluateThing(s,e,i),l=u instanceof Array;o instanceof Array||(o=[o]);for(var c in o){var h,f=o[c];h=l?u[c]:u,n.push(f),r.push(h)}}},this.makeItems=function(t,e,i,r,n){if(this.beforeFilter){var a=this.beforeFilter(t,e);if(a!=e)return void this.makeItems(t,a,i,r,n)}var s=[],o=[];this._makeChoices(this.choices,t,e,s,o);var u=this._mkAttachments(t,e,o),l=this.itemTrans;this._selectItems(s,o,function(t){if(t){var e=function(t){var e=t.documentURI,i=l;void 0===i&&(i=FW.getScraper(t,e)),void 0===i||i.makeItems(t,e,u[e],r,function(){})};Zotero.Utilities.processDocuments(t,e,n)}else n()})}},FW._MultiScraper.prototype=new FW._Base,FW.WebDelegateTranslator=function(t){return new FW._WebDelegateTranslator(t)},FW._WebDelegateTranslator=function(t){for(x in t)this[x]=t[x];this.makeItems=function(t,e,i,r,n){var a=this,s=Zotero.loadTranslator("web");s.setHandler("itemDone",function(i,n){r(n,a,t,e)}),s.setDocument(t),this.translatorId?(s.setTranslator(this.translatorId),s.translate()):(s.setHandler("translators",function(t,e){e.length&&(s.setTranslator(e[0]),s.translate())}),s.getTranslators()),n()}},FW._WebDelegateTranslator.prototype=new FW._Base,FW._StringMagic=function(){this._filters=new Array,this.addFilter=function(t){return this._filters.push(t),this},this.split=function(t){return this.addFilter(function(e){return e.split(t).filter(function(t){return""!=t})})},this.replace=function(t,e,i){return this.addFilter(function(r){return r.match(t)?r.replace(t,e,i):r})},this.prepend=function(t){return this.replace(/^/,t)},this.append=function(t){return this.replace(/$/,t)},this.remove=function(t,e){return this.replace(t,"",e)},this.trim=function(){return this.addFilter(function(t){return Zotero.Utilities.trim(t)})},this.trimInternal=function(){return this.addFilter(function(t){return Zotero.Utilities.trimInternal(t)})},this.match=function(t,e){return e||(e=0),this.addFilter(function(i){var r=i.match(t);return void 0===r||null===r?void 0:r[e]})},this.cleanAuthor=function(t,e){return this.addFilter(function(i){return Zotero.Utilities.cleanAuthor(i,t,e)})},this.key=function(t){return this.addFilter(function(e){return e[t]})},this.capitalizeTitle=function(){return this.addFilter(function(t){return Zotero.Utilities.capitalizeTitle(t)})},this.unescapeHTML=function(){return this.addFilter(function(t){return Zotero.Utilities.unescapeHTML(t)})},this.unescape=function(){return this.addFilter(function(t){return unescape(t)})},this._applyFilters=function(t,e){for(i in this._filters){t=flatten(t),t=t.filter(function(t){return void 0!==t&&null!==t});for(var r=0;r<t.length;r++)try{if(void 0===t[r]||null===t[r])continue;t[r]=this._filters[i](t[r],e)}catch(n){t[r]=void 0,Zotero.debug("Caught exception "+n+"on filter: "+this._filters[i])}t=t.filter(function(t){return void 0!==t&&null!==t})}return flatten(t)}},FW.PageText=function(){return new FW._PageText},FW._PageText=function(){this._filters=new Array,this.evaluate=function(t){var e=[t.documentElement.innerHTML];return e=this._applyFilters(e,t),0==e.length?!1:e}},FW._PageText.prototype=new FW._StringMagic,FW.Url=function(){return new FW._Url},FW._Url=function(){this._filters=new Array,this.evaluate=function(t,e){var i=[e];return i=this._applyFilters(i,t),0==i.length?!1:i}},FW._Url.prototype=new FW._StringMagic,FW.Xpath=function(t){return new FW._Xpath(t)},FW._Xpath=function(t){this._xpath=t,this._filters=new Array,this.text=function(){var t=function(t){return"object"==typeof t&&t.textContent?t.textContent:t};return this.addFilter(t),this},this.sub=function(t){var e=function(e,i){var r=i.evaluate(t,e,null,XPathResult.ANY_TYPE,null);return r?r.iterateNext():void 0};return this.addFilter(e),this},this.evaluate=function(t){var e=t.evaluate(this._xpath,t,null,XPathResult.ANY_TYPE,null),i=e.resultType,r=new Array;if(i==XPathResult.STRING_TYPE)r.push(e.stringValue);else if(i==XPathResult.BOOLEAN_TYPE)r.push(e.booleanValue);else if(i==XPathResult.NUMBER_TYPE)r.push(e.numberValue);else if(i==XPathResult.ORDERED_NODE_ITERATOR_TYPE||i==XPathResult.UNORDERED_NODE_ITERATOR_TYPE)for(var n;n=e.iterateNext();)r.push(n);return r=this._applyFilters(r,t),0==r.length?!1:r}},FW._Xpath.prototype=new FW._StringMagic,FW.detectWeb=function(t,e){for(var i in FW._scrapers){var r=FW._scrapers[i],n=r.evaluateThing(r.itemType,t,e),a=r.evaluateThing(r.detect,t,e);if(a.length>0&&a[0])return n}},FW.getScraper=function(t,e){var i=FW.detectWeb(t,e);return FW._scrapers.filter(function(r){return r.evaluateThing(r.itemType,t,e)==i&&r.evaluateThing(r.detect,t,e)})[0]},FW.doWeb=function(t,e){var i=FW.getScraper(t,e);i.makeItems(t,e,[],function(t,e,i,r){e.callHook("scraperDone",t,i,r),t.title||(t.title=""),t.complete()},function(){Zotero.done()}),Zotero.wait()};
-function detectWeb(doc, url) { 
-	// Diff interface is not supported
+
+function detectWeb(doc, url) {
+	// Diff 界面不支持
 	if (new URLSearchParams(doc.location.search).get('diff')) {
 		return false;
 	}
-	
-	return FW.detectWeb(doc, url);
+	// 文件页
+	if (/\/wiki\/File:/.test(url) || /[?&]title=File:/.test(url)) {
+		if (doc.querySelector('#file, .fullImageLink, #fileinfotpl_desc, table.fileinfotpl')) {
+			return isBookFile(doc) ? 'book' : 'artwork';
+		}
+		return false;
+	}
+	// 搜索结果页
+	if (doc.querySelector('ul.search-results')) {
+		return 'multiple';
+	}
+	// 画廊
+	if (doc.querySelector('ul.gallery')) {
+		return 'multiple';
+	}
+	return false;
 }
-function doWeb(doc, url) { return FW.doWeb(doc, url); }
 
-/*
-	***** BEGIN LICENSE BLOCK *****
+function isBookFile(doc) {
+	// PDF/DjVu 文件页视为图书
+	const link = doc.querySelector('#file a[href*="upload.wikimedia.org"], div.fullImageLink a');
+	return !!(link && /\.(pdf|djvu)(\?|#|$)/i.test(link.href));
+}
 
-	Wikimedia Commons Translator
-	Copyright © 2012 Sebastian Karcher
+function getSearchResults(doc) {
+	const items = {};
+	// 搜索结果页
+	if (doc.querySelector('ul.search-results')) {
+		const links = doc.querySelectorAll('ul.search-results a[title*="File:"]');
+		for (const link of links) {
+			const title = ZU.trimInternal(link.textContent);
+			const href = link.href;
+			if (!title || !href) continue;
+			items[href] = title;
+		}
+	}
+	// 画廊页
+	else if (doc.querySelector('ul.gallery')) {
+		const links = doc.querySelectorAll('ul.gallery a.image');
+		const texts = doc.querySelectorAll('ul.gallery .gallerytext');
+		for (let i = 0; i < links.length; i++) {
+			const href = links[i].href;
+			const title = texts[i] ? ZU.trimInternal(texts[i].textContent) : '';
+			if (!href || !title) continue;
+			items[href] = title;
+		}
+	}
+	return Object.keys(items).length ? items : false;
+}
 
-	This file is part of Zotero.
+async function doWeb(doc, url) {
+	if (detectWeb(doc, url) === 'multiple') {
+		const searchResults = getSearchResults(doc);
+		if (!searchResults) return;
+		const items = await Z.selectItems(searchResults);
+		if (!items) return;
+		await processDocuments(Object.keys(items), scrape);
+	}
+	else {
+		await scrape(doc, url);
+	}
+}
 
-	Zotero is free software: you can redistribute it and/or modify
-	it under the terms of the GNU Affero General Public License as published by
-	the Free Software Foundation, either version 3 of the License, or
-	(at your option) any later version.
+async function scrape(doc, url) {
+	const wikitext = await getWikitext(url);
+	if (wikitext) {
+		try {
+			const book = extractTemplate(wikitext, 'Book');
+			if (book) {
+				scrapeBook(doc, url, book);
+				return;
+			}
+			const info = extractTemplate(wikitext, 'Information');
+			if (info) {
+				scrapeInformation(doc, url, info);
+				return;
+			}
+		}
+		catch (e) {
+			Z.debug('Wikimedia Commons: wikitext scraping failed, falling back to DOM: ' + e);
+		}
+	}
+	// DOM 兜底
+	if (isBookFile(doc)) {
+		scrapeBookFromDOM(doc, url);
+		return;
+	}
+	scrapeFromDOM(doc, url);
+}
 
-	Zotero is distributed in the hope that it will be useful,
-	but WITHOUT ANY WARRANTY; without even the implied warranty of
-	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-	GNU Affero General Public License for more details.
+async function getWikitext(url) {
+	const m = url.match(/\/wiki\/(File:[^?#]+)/) || url.match(/[?&]title=(File:[^&#]+)/);
+	if (!m) return '';
+	let page = m[1];
+	// URL 中的页面名是百分号编码的，必须先解码再重新编码，避免双重编码
+	try {
+		page = decodeURIComponent(page);
+	}
+	catch (e) {
+		// 解码失败则使用原样
+	}
+	page = page.replace(/_/g, ' ');
+	const apiUrl = 'https://commons.wikimedia.org/w/api.php?action=parse&format=json&formatversion=2&prop=wikitext&origin=*&page='
+		+ encodeURIComponent(page);
+	// 优先使用 requestJSON（现代 API），不可用时回退到 requestText
+	try {
+		const data = await requestJSON(apiUrl);
+		return (data.parse && data.parse.wikitext) ? data.parse.wikitext : '';
+	}
+	catch (e) {
+		Z.debug('Wikimedia Commons: requestJSON failed: ' + e);
+	}
+	// 回退到 requestText + JSON.parse
+	try {
+		const text = await requestText(apiUrl);
+		const data = JSON.parse(text);
+		return (data.parse && data.parse.wikitext) ? data.parse.wikitext : '';
+	}
+	catch (e) {
+		Z.debug('Wikimedia Commons: requestText failed: ' + e);
+	}
+	return '';
+}
 
-	You should have received a copy of the GNU Affero General Public License
-	along with Zotero. If not, see <http://www.gnu.org/licenses/>.
+// 从 wikitext 中提取 {{Name ...}} 模板体（花括号配平）
+function extractTemplate(wikitext, name) {
+	if (!wikitext) return null;
+	const re = new RegExp('\\{\\{\\s*' + name + '\\b', 'i');
+	const startMatch = re.exec(wikitext);
+	if (!startMatch) return null;
+	const start = startMatch.index;
+	let depth = 0;
+	for (let i = start; i < wikitext.length; i++) {
+		if (wikitext.startsWith('{{', i)) {
+			depth++;
+			i++;
+		}
+		else if (wikitext.startsWith('}}', i)) {
+			depth--;
+			if (depth === 0) {
+				return wikitext.slice(start + 2, i);
+			}
+			i++;
+		}
+	}
+	return null;
+}
 
-	***** END LICENSE BLOCK *****
-*/
-
-
-/**Art Images*/
-FW.Scraper({
-	itemType : 'artwork',
-	detect : FW.Xpath('//td[@id="fileinfotpl_art_title" or @id="fileinfotpl_desc"]'),
-	title : FW.Xpath('//td[@id="fileinfotpl_art_title" or @id="fileinfotpl_desc"]/following-sibling::td').text().trim().remove(/\n.+/g),
-	attachments : [
-	{
-		url : FW.Xpath('//div[@id="file"]/a/@href').text().prepend("http:"),
-		title : "Wikimedia Image"
-	}],
-	creators : FW.Xpath('//tr/td[@id="fileinfotpl_aut"]/following-sibling::td').text().remove(/\n/g).remove(/\(.+/).cleanAuthor("author"),
-	artworkSize : FW.Xpath('//tr/td[@id="fileinfotpl_art_dimensions"]/following-sibling::td').text(),
-	artworkMedium : FW.Xpath('//tr/td[@id="fileinfotpl_art_medium"]/following-sibling::td').text(),
-	date : FW.Xpath('//tr/td[@id="fileinfotpl_date"]/following-sibling::td').text(),
-	archive : FW.Xpath('//tr/td[@id="fileinfotpl_art_gallery"]/following-sibling::td').text().trim().remove(/\n.+/g),
-	rights : FW.Xpath('//table[@class="licensetpl" or @class="layouttemplate licensetpl"]/tbody/tr/td[2]|//table[@class="licensetpl" or @class="layouttemplate licensetpl"]/tbody/tr/td/span').text(),
-
-	hooks : {
-		"scraperDone": function  (item,doc, url) {
-			if (!item.archive) item.archive = ZU.xpathText(doc, '//tr/td[@id="fileinfotpl_src"]/following-sibling::td');
-			item.date = item.date ? item.date : item.runningTime;
-			item.runningTime = undefined;
-			for (let i in item.creators) {
-				if (!item.creators[i].firstName){
-					item.creators[i].fieldMode=1;
+// 提取 wikitext 中所有名为 name 的模板体
+function extractAllTemplates(wikitext, name) {
+	const results = [];
+	if (!wikitext) return results;
+	const re = new RegExp('\\{\\{\\s*' + name + '\\b', 'ig');
+	let startMatch;
+	while ((startMatch = re.exec(wikitext))) {
+		const start = startMatch.index;
+		let depth = 0;
+		let i = start;
+		for (; i < wikitext.length; i++) {
+			if (wikitext.startsWith('{{', i)) {
+				depth++;
+				i++;
+			}
+			else if (wikitext.startsWith('}}', i)) {
+				depth--;
+				if (depth === 0) {
+					results.push(wikitext.slice(start + 2, i));
+					re.lastIndex = i + 2;
+					break;
 				}
+				i++;
 			}
 		}
 	}
-});
+	return results;
+}
 
-/**Photos*/
-FW.Scraper({
-	itemType : 'artwork',
-	detect : FW.Xpath('//span[@class="description"]'),
-	title : FW.Xpath('//span[@class="description"]').text().trim(),
-	attachments : [
-	{
-		url : FW.Xpath('//div[@id="file"]/a/@href').text().prepend("http:"),
-		title : "Wikimedia Image"
-	}],
-	creators : FW.Xpath('//tr/td[@id="fileinfotpl_aut"]/following-sibling::td').text().remove(/\n/g).remove(/\(.+/).cleanAuthor("author"),
-	date : FW.Xpath('//tr/td[@id="fileinfotpl_date"]/following-sibling::td').text(),
-	archive : FW.Xpath('//tr/td[@id="fileinfotpl_src"]/following-sibling::td').text(),
-	rights : FW.Xpath('//table[@class="licensetpl" or @class="layouttemplate licensetpl"]/tbody/tr/td[2]|//table[@class="licensetpl" or @class="layouttemplate licensetpl"]/tbody/tr/td/span').text(),
-	//fix authors w/o first names to single field mode
-	hooks : {
-  	"scraperDone": function  (item,doc, url) {
-			item.date = item.date ? item.date : item.runningTime;
-			item.runningTime = undefined;
-			for (let i in item.creators) {
-				if (!item.creators[i].firstName){
-					item.creators[i].fieldMode=1;
-				}
+// 解析模板体为 参数名(小写)→值 的映射（跳过模板名）
+function parseTemplateParams(body) {
+	const params = {};
+	// 跳过模板名，定位到第一个参数分隔符
+	let i = 0;
+	while (i < body.length && body[i] !== '|') i++;
+	i++;
+	let key = '';
+	let val = '';
+	let afterEq = false;
+	let depth = 0;
+	let linkDepth = 0;
+	const flush = function () {
+		if (!afterEq && !key.trim()) return;
+		const k = afterEq ? key.trim().toLowerCase() : String(Object.keys(params).length + 1);
+		const v = (afterEq ? val : key + val).trim();
+		if (!k || !v) return;
+		if (!(k in params)) params[k] = v;
+	};
+	for (; i < body.length; i++) {
+		const c = body[i];
+		const n = body[i + 1];
+		if (c === '{' && n === '{') {
+			depth++;
+			if (afterEq) val += '{{';
+			else key += '{{';
+			i++;
+			continue;
+		}
+		if (c === '}' && n === '}') {
+			depth--;
+			if (afterEq) val += '}}';
+			else key += '}}';
+			i++;
+			continue;
+		}
+		if (c === '[' && n === '[') {
+			linkDepth++;
+			if (afterEq) val += '[[';
+			else key += '[[';
+			i++;
+			continue;
+		}
+		if (c === ']' && n === ']') {
+			linkDepth--;
+			if (afterEq) val += ']]';
+			else key += ']]';
+			i++;
+			continue;
+		}
+		if (c === '|' && depth <= 0 && linkDepth <= 0) {
+			flush();
+			key = '';
+			val = '';
+			afterEq = false;
+			continue;
+		}
+		if (c === '=' && !afterEq && depth <= 0 && linkDepth <= 0) {
+			afterEq = true;
+			continue;
+		}
+		if (afterEq) val += c;
+		else key += c;
+	}
+	flush();
+	return params;
+}
+
+// 清理 wikitext 值：去语言模板/链接/注释/标签
+// 保留换行（作者参数常以换行分隔多作者）
+function cleanWikitext(value) {
+	if (!value) return '';
+	let v = value;
+	// HTML 注释
+	v = v.replace(/<!--[\s\S]*?-->/g, '');
+	// 语言包装模板 {{en|1=...}} / {{lang|xx|...}} → 内容
+	v = v.replace(/\{\{\s*(?:en|zh|zh-hans|zh-hant|zh-cn|zh-tw|zh-hk|zh-sg|ja|ko|fr|de|es|ru|it|pt|la|mul|lang)\s*([^{}]*)\}\}/gi, function (match, rest) {
+		const parts = rest.split('|');
+		const last = parts[parts.length - 1] || '';
+		const m = last.match(/^\s*(?:\d+\s*=)?\s*(.+?)\s*$/);
+		return m ? m[1] : '';
+	});
+	// 内部链接 [[a|b]] → b，[[a]] → a
+	v = v.replace(/\[\[([^\]|]*)\|([^\]]*)\]\]/g, '$2');
+	v = v.replace(/\[\[([^\]]*)\]\]/g, '$1');
+	// 作者模板 {{Creator:Name}} / {{Author:Name}} → Name
+	v = v.replace(/\{\{\s*(?:Creator|Author)\s*:\s*([^{}]*?)\s*\}\}/gi, '$1');
+	// DOI {{doi|...}} → 值
+	v = v.replace(/\{\{\s*doi\s*\|([^{}]*?)\}\}/gi, '$1');
+	// 机构模板 {{Institution:Name}} → Name
+	v = v.replace(/\{\{\s*Institution\s*:\s*([^{}]*?)\s*\}\}/gi, '$1');
+	// CADAL 链接 {{China Academic Digital Associative Library link|ID}} → CADAL: ID
+	v = v.replace(/\{\{\s*China Academic Digital Associative Library link\s*\|([^{}]*?)\s*\}\}/gi, 'CADAL: $1');
+	// PDF 页链接 {{PDF page link|page=N|text=T}} → T
+	v = v.replace(/\{\{\s*PDF page link\s*\|[^{}]*?text\s*=\s*([^{}]*?)\s*\}\}/gi, '$1');
+	// 移除剩余模板
+	v = v.replace(/\{\{[^{}]*\}\}/g, '');
+	// 移除引用与标签
+	v = v.replace(/<ref[^>]*>[\s\S]*?<\/ref>/g, '');
+	v = v.replace(/<[^>]+>/g, '');
+	// 压缩空白，保留单个换行
+	return v.replace(/[ \t\u00a0\u200b\u200c]+/g, ' ')
+		.replace(/ *\n */g, '\n')
+		.replace(/\n{2,}/g, '\n')
+		.trim();
+}
+
+// 单行清理（标题/出版社等不应包含换行的字段）
+function cleanSingle(value) {
+	return cleanWikitext(value).replace(/\n/g, ' ');
+}
+
+// 语言代码映射
+function mapLanguage(lang) {
+	if (!lang) return '';
+	const l = lang.toLowerCase();
+	const map = {
+		'chinese': 'zh',
+		'english': 'en',
+		'japanese': 'ja',
+		'french': 'fr',
+		'german': 'de',
+		'spanish': 'es',
+		'russian': 'ru',
+		'italian': 'it',
+		'portuguese': 'pt',
+		'latin': 'la',
+		'korean': 'ko'
+	};
+	if (map[l]) return map[l];
+	return /^[a-z]{2,3}(-[a-z]{2,4})?$/i.test(l) ? l : '';
+}
+
+function pushCreator(item, name, creatorType = 'author') {
+	let n = (name || '').replace(/ほか$/, '').trim();
+	n = n.replace(/[著編撰譯注校訂整理]+$/, '').trim();
+	if (!n) return;
+	if (/^(unknown|anonym|anonymous|anon|unknown author)[：:]?\s*$/i.test(n)) return;
+	if (/^Q\d+$/.test(n)) return;
+	if (/[\u4e00-\u9fff]/.test(n)) {
+		item.creators.push({
+			lastName: n,
+			creatorType: creatorType,
+			fieldMode: 1
+		});
+	}
+	else {
+		const creator = ZU.cleanAuthor(n, creatorType);
+		if (creator.lastName) {
+			item.creators.push(creator);
+		}
+	}
+}
+
+// 解析作者字符串（支持多作者；作者可能以换行/分号/逗号分隔）
+// 兼容 NDL 目录格式 "姓, 名, 生卒年"（如 "久保, 良英, 1883-1942"）
+function addCreators(item, authorString, creatorType = 'author') {
+	if (!authorString) return;
+	// 按换行/分号分为多个作者组
+	const groups = authorString.split(/[\n;；]+/);
+	for (const group of groups) {
+		const g = group.trim();
+		if (!g) continue;
+		// NDL 格式：姓, 名, 生卒年（有生卒年佐证，可安全合并）
+		const ndl = g.match(/^([\u3040-\u30ff\u4e00-\u9fa5]{1,8})\s*[,，]\s*([\u3040-\u30ff\u4e00-\u9fa5]{1,8})\s*[,，]\s*\d{4}\s*[-–]\s*\d{4}$/);
+		if (ndl) {
+			pushCreator(item, ndl[1] + ndl[2], creatorType);
+			continue;
+		}
+		// 假名形式的 姓, 名（日文名，无生卒年）
+		const ndlKana = g.match(/^([\u3040-\u30ff]{1,8})\s*[,，]\s*([\u3040-\u30ff]{1,8})$/);
+		if (ndlKana) {
+			pushCreator(item, ndlKana[1] + ndlKana[2], creatorType);
+			continue;
+		}
+		// 西文 姓名, 生卒年
+		const west = g.match(/^([A-Za-zÀ-ÿ' .-]{2,})\s*,\s*\d{4}\s*[-–]\s*\d{4}$/);
+		if (west) {
+			pushCreator(item, west[1], creatorType);
+			continue;
+		}
+		// 常规：按逗号/顿号拆分
+		for (const seg of g.split(/[,，、]+/)) {
+			pushCreator(item, seg, creatorType);
+		}
+	}
+}
+
+// 从文件页 DOM 中取 "Original file" 链接（原文件直链）
+function getOriginalFileURL(doc) {
+	let link = doc.querySelector('#file a[href*="upload.wikimedia.org"]')
+		|| doc.querySelector('div.fullImageLink a')
+		|| doc.querySelector('#file a[href*="special/filepath"]');
+	if (link && link.href) return link.href;
+	const img = doc.querySelector('#file img');
+	if (img && img.src) return img.src;
+	return '';
+}
+
+function getMimeType(url) {
+	const ext = (url.match(/\.([a-z0-9]+)(\?|#|$)/i) || [])[1];
+	const map = {
+		'pdf': 'application/pdf',
+		'djvu': 'image/vnd.djvu',
+		'jpg': 'image/jpeg',
+		'jpeg': 'image/jpeg',
+		'png': 'image/png',
+		'tif': 'image/tiff',
+		'tiff': 'image/tiff',
+		'gif': 'image/gif'
+	};
+	return map[(ext || '').toLowerCase()] || '';
+}
+
+function addFileAttachment(item, doc, isBook) {
+	const fileURL = getOriginalFileURL(doc);
+	if (!fileURL) return;
+	const mimeType = getMimeType(fileURL);
+	if (isBook) {
+		const title = /\.pdf$/i.test(fileURL) ? 'Full Text PDF' : decodeURIComponent(fileURL.split('/').pop() || '');
+		item.attachments.push({
+			title: title,
+			mimeType: mimeType,
+			url: fileURL
+		});
+	}
+	else {
+		item.attachments.push({
+			title: 'Wikimedia Image',
+			mimeType: mimeType,
+			url: fileURL
+		});
+	}
+}
+
+// 从 DOM 单元格取渲染后的值（模板渲染结果），无 {{ 时用 wikitext 清理值
+function hybridValue(rawWikitext, doc, id) {
+	if (rawWikitext && !rawWikitext.includes('{{')) {
+		return cleanWikitext(rawWikitext);
+	}
+	const el = doc.getElementById(id);
+	const cell = el && el.nextElementSibling;
+	if (cell) {
+		return ZU.trimInternal(cell.textContent);
+	}
+	return rawWikitext ? cleanWikitext(rawWikitext) : '';
+}
+
+// 去除描述开头的语言前缀，如 "English: xxx" / "中文（简体）：xxx"
+function stripLangPrefix(str) {
+	return str.replace(/^\s*(中文(（简体|繁體）)?|English|日本語|Français|Deutsch|Русский|Español)\s*[:：]\s*/, '').trim();
+}
+
+// 解析 {{Information field|name=X|value=Y}} 序列（{{Book}} 的 Other_fields 参数）
+function parseOtherFields(raw) {
+	const fields = {};
+	if (!raw) return fields;
+	for (const body of extractAllTemplates(raw, 'Information field')) {
+		const params = parseTemplateParams('Book|' + body);
+		const name = cleanSingle(params['name']);
+		const value = cleanSingle(params['value']);
+		if (name && value && !(name in fields)) fields[name] = value;
+	}
+	return fields;
+}
+
+// 从日期值提取开头年份/年月，其余（如民国纪年注解）留给 extra
+function extractDate(rawDate) {
+	const m = rawDate.match(/^\d{4}(?:-\d{1,2}(?:-\d{1,2})?)?/);
+	return m ? m[0] : '';
+}
+
+// {{Book}} 模板 → book
+function scrapeBook(doc, url, body) {
+	const params = parseTemplateParams(body);
+	const otherFields = parseOtherFields(params['other fields'] || params['other_fields']);
+	const item = new Z.Item('book');
+	item.url = url;
+	item.libraryCatalog = 'Wikimedia Commons';
+
+	// 标题
+	const title = cleanSingle(params['title']);
+	item.title = title || ZU.trimInternal(doc.querySelector('#firstHeading').textContent).replace(/^File:/, '').trim();
+
+	// 作者：优先 Author 参数，其次 Other_fields 的 Creator
+	const author = cleanWikitext(params['author']);
+	if (author) addCreators(item, author);
+	if (!item.creators.length) {
+		const creator = cleanWikitext(otherFields['Creator']);
+		if (creator) addCreators(item, creator);
+	}
+	// 译者
+	const translator = cleanWikitext(params['translator']);
+	if (translator) addCreators(item, translator, 'translator');
+
+	// 出版社与出版地（支持 "地点：出版社" 与 "出版社·地点" 两种格式）
+	const publisherRaw = cleanSingle(params['publisher'] || params['printer']);
+	if (publisherRaw) {
+		const pubColon = publisherRaw.match(/^(.+?)[：:]\s*(.+)$/);
+		if (pubColon) {
+			item.place = pubColon[1].trim();
+			item.publisher = pubColon[2].trim();
+		}
+		else {
+			const pubParts = publisherRaw.split(/[·・]/);
+			if (pubParts.length >= 2) {
+				item.publisher = pubParts[0].trim();
+				item.place = pubParts[pubParts.length - 1].trim();
+			}
+			else {
+				item.publisher = publisherRaw;
 			}
 		}
 	}
-});
-
-/** Search results */
-FW.MultiScraper({
-	itemType : "multiple",
-	detect : FW.Xpath('//ul[contains(@class, "search-results")]'),
-	choices : {
-		titles : FW.Xpath('//ul[contains(@class, "search-results")]//a[contains(@title, "File:")]').text(),
-		urls : FW.Xpath('//ul[contains(@class, "search-results")]//a[contains(@title, "File:")]').key('href').text()
+	// 出版地：优先 Other_fields 的 Publication Place，其次 City 参数（排除国家代码）
+	if (!item.place) {
+		const pubPlace = cleanSingle(otherFields['Publication Place']);
+		if (pubPlace) {
+			item.place = pubPlace;
+		}
+		else {
+			const city = cleanSingle(params['city'] || params['place of publication']);
+			if (city && !/^[a-z]{2}$/i.test(city)) item.place = city;
+		}
 	}
-});
 
-/**Galleries */
-FW.MultiScraper({
-	itemType : "multiple",
-	detect : FW.Xpath('//ul[contains(@class, "gallery")]'),
-	choices : {
-  	titles : FW.Xpath('//ul[contains(@class, "gallery")]//div[@class="gallerytext"]').text(),
-  	urls : FW.Xpath('//ul[contains(@class, "gallery")]//a[@class="image"]').key('href').text()
+	// 日期（提取开头年月，纪年注解放入 extra）
+	const rawDate = cleanSingle(params['publication date'] || params['date'] || params['year']);
+	if (rawDate) {
+		const date = extractDate(rawDate);
+		if (date) item.date = date;
+		else item.date = rawDate;
 	}
-});
+
+	const language = mapLanguage(cleanSingle(params['language']));
+	if (language) item.language = language;
+
+	const isbn = cleanSingle(params['isbn']);
+	if (isbn) {
+		const isbnMatch = isbn.match(/(\d[\dXx-]{9,})/);
+		if (isbnMatch) item.ISBN = ZU.cleanISBN(isbnMatch[1]);
+	}
+
+	const volume = cleanSingle(params['volume']);
+	if (volume) item.volume = volume;
+
+	const edition = cleanSingle(params['edition']);
+	if (edition) item.edition = edition;
+
+	// 页数：Book 的 Pages 参数或 Other_fields 的 Extent（如 "604p ; 19cm"）
+	const pages = cleanSingle(params['pages']);
+	if (pages) {
+		const pageMatch = pages.match(/(\d+)\s*页?p?/i);
+		if (pageMatch) item.numPages = pageMatch[1];
+	}
+	if (!item.numPages) {
+		const extent = cleanSingle(otherFields['Extent']);
+		if (extent) {
+			const extentMatch = extent.match(/(\d+)\s*页?p?/i);
+			if (extentMatch) item.numPages = extentMatch[1];
+		}
+	}
+
+	const description = cleanSingle(params['description']);
+	if (description) item.abstractNote = description;
+
+	const source = cleanSingle(params['source']);
+	const extraParts = [];
+	if (source) {
+		// DOI（如 NDL 的 10.11501/969301）
+		const doiMatch = source.match(/10\.\d{4,9}\/[^\s]+/i);
+		if (doiMatch) item.DOI = doiMatch[0].replace(/\.$/, '');
+		extraParts.push('Source: ' + source);
+	}
+	// 纪年注解等日期补充信息
+	if (rawDate && item.date && rawDate !== item.date) {
+		extraParts.push('Publication date: ' + rawDate);
+	}
+	// Other_fields 中的其余元信息（跳过已映射字段与结构噪声字段）
+	for (const name of Object.keys(otherFields)) {
+		const lower = name.toLowerCase();
+		const value = otherFields[name];
+		if (lower === 'creator') continue;            // 已作作者处理
+		if (lower === 'publication place') continue;  // 已作出版地处理
+		if (lower === 'extent') continue;             // 已作页数处理
+		if (lower === 'page list' || lower === 'empty pages') continue; // 结构噪声
+		if (lower === 'call number') {
+			item.callNumber = value;
+			continue;
+		}
+		extraParts.push(name + ': ' + value);
+	}
+
+	if (extraParts.length) item.extra = extraParts.join('\n');
+
+	addFileAttachment(item, doc, true);
+	item.complete();
+}
+
+// {{Information}} 模板 → artwork（PDF/DjVu 则作为 book）
+function scrapeInformation(doc, url, body) {
+	const params = parseTemplateParams(body);
+	const isBook = isBookFile(doc);
+
+	const description = hybridValue(params['description'], doc, 'fileinfotpl_desc');
+	const title = stripLangPrefix(description);
+
+	const author = hybridValue(params['author'], doc, 'fileinfotpl_aut');
+	const date = cleanSingle(hybridValue(params['date'], doc, 'fileinfotpl_date'));
+	const source = cleanSingle(hybridValue(params['source'], doc, 'fileinfotpl_src'));
+	const permission = cleanSingle(hybridValue(params['permission'], doc, 'fileinfotpl_perm'))
+		|| textFromLicensetpl(doc);
+
+	if (isBook) {
+		const item = new Z.Item('book');
+		item.url = url;
+		item.libraryCatalog = 'Wikimedia Commons';
+		item.title = title || ZU.trimInternal(doc.querySelector('#firstHeading').textContent).replace(/^File:/, '').trim();
+		addCreators(item, author);
+		if (date) item.date = date;
+		if (source) item.extra = 'Source: ' + source;
+		addFileAttachment(item, doc, true);
+		item.complete();
+		return;
+	}
+
+	const item = new Z.Item('artwork');
+	item.url = url;
+	item.libraryCatalog = 'Wikimedia Commons';
+	item.title = title;
+	addCreators(item, author);
+	if (date) item.date = date;
+	if (source) item.archive = source;
+	if (permission) item.rights = permission;
+	addFileAttachment(item, doc, false);
+	item.complete();
+}
+
+// 兜底：从 DOM 的 fileinfotpl_* ID 直接提取（API 不可用时）
+// 不依赖 findBookTable 的文本匹配，直接用 ID 定位更可靠
+function scrapeBookFromDOM(doc, url) {
+	const item = new Z.Item('book');
+	item.url = url;
+	item.libraryCatalog = 'Wikimedia Commons';
+
+	// 直接用 fileinfotpl_* ID 取值（th 的 nextElementSibling 即 td）
+	const valById = function (id) {
+		const el = doc.getElementById(id);
+		if (el && el.nextElementSibling) {
+			return ZU.trimInternal(el.nextElementSibling.textContent);
+		}
+		return '';
+	};
+
+	let title = valById('fileinfotpl_art_title');
+	if (!title) {
+		const heading = doc.querySelector('#firstHeading');
+		title = heading ? ZU.trimInternal(heading.textContent).replace(/^File:/, '').trim() : '';
+	}
+	item.title = title;
+
+	const author = valById('fileinfotpl_aut');
+	if (author) addCreators(item, author);
+
+	// 出版社与出版地（支持 "地点：出版社" 与 "出版社·地点" 两种格式）
+	const publisherRaw = valById('fileinfotpl_book_publisher');
+	if (publisherRaw) {
+		const pubColon = publisherRaw.match(/^(.+?)[：:]\s*(.+)$/);
+		if (pubColon) {
+			item.place = pubColon[1].trim();
+			item.publisher = pubColon[2].trim();
+		}
+		else {
+			const pubParts = publisherRaw.split(/[·・]/);
+			if (pubParts.length >= 2) {
+				item.publisher = pubParts[0].trim();
+				item.place = pubParts[pubParts.length - 1].trim();
+			}
+			else {
+				item.publisher = publisherRaw;
+			}
+		}
+	}
+	if (!item.place) {
+		const place = valById('fileinfotpl_book_place-of-publication');
+		if (place && !/^[a-z]{2}$/i.test(place)) item.place = place;
+	}
+
+	const date = valById('fileinfotpl_publication_date') || valById('fileinfotpl_date');
+	if (date) {
+		const dateMatch = extractDate(date);
+		item.date = dateMatch || date;
+	}
+
+	const langRaw = valById('fileinfotpl_book_language');
+	if (langRaw) {
+		const lang = mapLanguage(langRaw);
+		if (lang) item.language = lang;
+	}
+
+	const edition = valById('fileinfotpl_edition');
+	if (edition) item.edition = edition;
+
+	const isbn = valById('fileinfotpl_isbn');
+	if (isbn) {
+		const isbnMatch = isbn.match(/(\d[\dXx-]{9,})/);
+		if (isbnMatch) item.ISBN = ZU.cleanISBN(isbnMatch[1]);
+	}
+
+	// Source 字段：DOM 渲染的 source 单元格可能包含大量机构信息，只取前面部分
+	const source = valById('fileinfotpl_src');
+	const extraParts = [];
+	if (source) {
+		// 截取前 200 字符避免机构模板的长文本
+		const shortSource = source.slice(0, 200);
+		extraParts.push('Source: ' + shortSource);
+	}
+	if (date && item.date && date !== item.date) {
+		extraParts.push('Publication date: ' + date);
+	}
+	if (extraParts.length) item.extra = extraParts.join('\n');
+
+	addFileAttachment(item, doc, true);
+	item.complete();
+}
+
+// 兼容旧调用：查找 {{Book}} 渲染表格
+function findBookTable(doc) {
+	const tables = doc.querySelectorAll('table');
+	for (const table of tables) {
+		const rows = table.querySelectorAll('tr');
+		for (const row of rows) {
+			const cells = row.querySelectorAll('th, td');
+			if (cells.length < 2) continue;
+			const label = ZU.trimInternal(cells[0].textContent).toLowerCase();
+			if (label === 'title' || label === 'author') {
+				return table;
+			}
+		}
+	}
+	return null;
+}
+
+// 兜底：普通图片/照片页
+function scrapeFromDOM(doc, url) {
+	const item = new Z.Item('artwork');
+	item.url = url;
+	item.libraryCatalog = 'Wikimedia Commons';
+
+	const titleCell = doc.getElementById('fileinfotpl_art_title') || doc.getElementById('fileinfotpl_desc');
+	if (titleCell && titleCell.nextElementSibling) {
+		item.title = stripLangPrefix(ZU.trimInternal(titleCell.nextElementSibling.textContent));
+	}
+	if (!item.title) {
+		item.title = ZU.trimInternal(doc.querySelector('#firstHeading').textContent).replace(/^File:/, '').trim();
+	}
+
+	const author = textAfterId(doc, 'fileinfotpl_aut');
+	if (author) addCreators(item, author);
+
+	const date = textAfterId(doc, 'fileinfotpl_date');
+	if (date) item.date = date;
+
+	const source = textAfterId(doc, 'fileinfotpl_src');
+	if (source) item.archive = source;
+
+	const rights = textAfterId(doc, 'fileinfotpl_perm') || textFromLicensetpl(doc);
+	if (rights) item.rights = rights;
+
+	addFileAttachment(item, doc, false);
+	item.complete();
+}
+
+function textAfterId(doc, id) {
+	const el = doc.getElementById(id);
+	if (el && el.nextElementSibling) {
+		return ZU.trimInternal(el.nextElementSibling.textContent);
+	}
+	return '';
+}
+
+function textFromLicensetpl(doc) {
+	const cell = doc.querySelector('table.licensetpl tbody tr td:nth-child(2), table.licensetpl tbody tr td span');
+	return cell ? ZU.trimInternal(cell.textContent) : '';
+}
+
 /** BEGIN TEST CASES **/
 var testCases = [
 	{
@@ -158,7 +812,7 @@ var testCases = [
 		"items": [
 			{
 				"itemType": "artwork",
-				"title": "English: Boy with a Basket of Fruit",
+				"title": "Boy with a Basket of Fruit",
 				"creators": [
 					{
 						"firstName": "",
@@ -169,17 +823,15 @@ var testCases = [
 				],
 				"date": "circa 1593",
 				"archive": "Galleria Borghese",
-				"artworkMedium": "oil on canvas",
-				"artworkSize": "70 × 67 cm",
 				"libraryCatalog": "Wikimedia Commons",
 				"rights": "Public domain",
-				"shortTitle": "English",
 				"url": "https://commons.wikimedia.org/wiki/File:Boy_with_a_Basket_of_Fruit-Caravaggio_(1593).jpg",
-			"attachments": [
-				{
-					"title": "Wikimedia Image"
-				}
-			],
+				"attachments": [
+					{
+						"title": "Wikimedia Image",
+						"mimeType": "image/jpeg"
+					}
+				],
 				"tags": [],
 				"notes": [],
 				"seeAlso": []
@@ -188,7 +840,7 @@ var testCases = [
 	},
 	{
 		"type": "web",
-		"url": "http://commons.wikimedia.org/w/index.php?search=peron&button=&title=Special%3ASearch&limit=100",
+		"url": "https://commons.wikimedia.org/w/index.php?search=peron&button=&title=Special%3ASearch&limit=100",
 		"items": "multiple"
 	},
 	{
@@ -197,7 +849,7 @@ var testCases = [
 		"items": [
 			{
 				"itemType": "artwork",
-				"title": "English: Portrait of Ambroise Vollard",
+				"title": "Portrait of Ambroise Vollard",
 				"creators": [
 					{
 						"firstName": "Paul",
@@ -207,17 +859,15 @@ var testCases = [
 				],
 				"date": "1899",
 				"archive": "Petit Palais, Paris",
-				"artworkMedium": "oil on canvas",
-				"artworkSize": "101 × 81 cm (39.8 × 31.9 in)",
 				"libraryCatalog": "Wikimedia Commons",
 				"rights": "Public domain",
-				"shortTitle": "English",
 				"url": "https://commons.wikimedia.org/wiki/File:Portrait_of_Ambroise_Vollard.jpg",
-			"attachments": [
-				{
-					"title": "Wikimedia Image"
-				}
-			],
+				"attachments": [
+					{
+						"title": "Wikimedia Image",
+						"mimeType": "image/jpeg"
+					}
+				],
 				"tags": [],
 				"notes": [],
 				"seeAlso": []
@@ -230,7 +880,7 @@ var testCases = [
 		"items": [
 			{
 				"itemType": "artwork",
-				"title": "English: Congressional Plaza, Buenos Aires, Argentina.",
+				"title": "Congressional Plaza, Buenos Aires, Argentina.",
 				"creators": [
 					{
 						"firstName": "",
@@ -243,13 +893,13 @@ var testCases = [
 				"archive": "Own work",
 				"libraryCatalog": "Wikimedia Commons",
 				"rights": "Permission is granted to copy, distribute and/or modify this document under the terms of the GNU Free Documentation License, Version 1.2 or any later version published by the Free Software Foundation; with no Invariant Sections, no Front-Cover Texts, and no Back-Cover Texts. A copy of the license is included in the section entitled GNU Free Documentation License.http://www.gnu.org/copyleft/fdl.htmlGFDLGNU Free Documentation Licensetruetrue",
-				"shortTitle": "English",
 				"url": "https://commons.wikimedia.org/wiki/File:Plaza_Congreso.JPG",
 				"attachments": [
-				{
-					"title": "Wikimedia Image"
-				}
-			],
+					{
+						"title": "Wikimedia Image",
+						"mimeType": "image/jpeg"
+					}
+				],
 				"tags": [],
 				"notes": [],
 				"seeAlso": []
@@ -260,6 +910,111 @@ var testCases = [
 		"type": "web",
 		"url": "http://commons.wikimedia.org/wiki/Commons:Valued_images_by_topic/Science",
 		"items": "multiple"
+	},
+	{
+		"type": "web",
+		"url": "https://commons.wikimedia.org/wiki/File:NDL969301_%E7%B2%BE%E7%A5%9E%E5%88%86%E6%9E%90%E6%B3%95_part4.pdf",
+		"items": [
+			{
+				"itemType": "book",
+				"title": "精神分析法",
+				"creators": [
+					{
+						"firstName": "",
+						"lastName": "久保良英",
+						"creatorType": "author",
+						"fieldMode": 1
+					}
+				],
+				"callNumber": "503-166",
+				"date": "1922",
+				"DOI": "10.11501/969301",
+				"edition": "増訂3版",
+				"extra": "Source: 10.11501/969301 National Diet Library\nPublication date: 1922 大正11\nSubject: NDC: 146\nMaterial Type: Book\nSource Identifier: JPNO: 43036499\nDate Digitized: W3CDTF: 2009-03-31\nAudience: 一般\nTitle Transcription: セイシン ブンセキホウ\nPublisher Transcription: チュウオウカン ショテン\nSource Identifier: NDLBibID: 000000583869\nCreator Transcription: NDLNA: クボ, ヨシヒデ\nCreator: NDLNAId: 00036666\nContents: 第七　グレデイヴア物語/592",
+				"language": "ja",
+				"libraryCatalog": "Wikimedia Commons",
+				"numPages": "604",
+				"place": "東京",
+				"publisher": "中央館書店",
+				"url": "https://commons.wikimedia.org/wiki/File:NDL969301_%E7%B2%BE%E7%A5%9E%E5%88%86%E6%9E%90%E6%B3%95_part4.pdf",
+				"attachments": [
+					{
+						"title": "Full Text PDF",
+						"mimeType": "application/pdf"
+					}
+				],
+				"tags": [],
+				"notes": [],
+				"seeAlso": []
+			}
+		]
+	},
+	{
+		"type": "web",
+		"url": "https://commons.wikimedia.org/wiki/File:CADAL03011260_%E7%B2%BE%E7%A5%9E%E5%88%86%E6%9E%90%E5%AD%B8ABC.djvu",
+		"items": [
+			{
+				"itemType": "book",
+				"title": "精神分析學ABC",
+				"creators": [
+					{
+						"firstName": "",
+						"lastName": "张东荪",
+						"creatorType": "author",
+						"fieldMode": 1
+					}
+				],
+				"date": "1929-05",
+				"extra": "Source: CADAL: 03011260 Jilin University\nPublication date: 1929-05（民国十八年）",
+				"language": "zh",
+				"libraryCatalog": "Wikimedia Commons",
+				"place": "上海",
+				"publisher": "世界书局",
+				"url": "https://commons.wikimedia.org/wiki/File:CADAL03011260_%E7%B2%BE%E7%A5%9E%E5%88%86%E6%9E%90%E5%AD%B8ABC.djvu",
+				"attachments": [
+					{
+						"title": "CADAL03011260_精神分析學ABC.djvu",
+						"mimeType": "image/vnd.djvu"
+					}
+				],
+				"tags": [],
+				"notes": [],
+				"seeAlso": []
+			}
+		]
+	},
+	{
+		"type": "web",
+		"url": "https://commons.wikimedia.org/wiki/File:SSID-12434636_%E7%B2%BE%E7%A5%9E%E5%88%86%E6%9E%90%E8%88%87%E5%94%AF%E7%89%A9%E5%8F%B2%E8%A7%80.pdf",
+		"items": [
+			{
+				"itemType": "book",
+				"title": "精神分析與唯物史觀",
+				"creators": [
+					{
+						"firstName": "",
+						"lastName": "奥斯旁",
+						"creatorType": "author",
+						"fieldMode": 1
+					}
+				],
+				"date": "1949",
+				"language": "zh",
+				"libraryCatalog": "Wikimedia Commons",
+				"place": "香港",
+				"publisher": "世界书局出版社",
+				"url": "https://commons.wikimedia.org/wiki/File:SSID-12434636_%E7%B2%BE%E7%A5%9E%E5%88%86%E6%9E%90%E8%88%87%E5%94%AF%E7%89%A9%E5%8F%B2%E8%A7%80.pdf",
+				"attachments": [
+					{
+						"title": "Full Text PDF",
+						"mimeType": "application/pdf"
+					}
+				],
+				"tags": [],
+				"notes": [],
+				"seeAlso": []
+			}
+		]
 	}
 ]
 /** END TEST CASES **/


### PR DESCRIPTION
新增三款 Zotero translator：

- **China National Library - Republic Era.js**：抓取国家图书馆民国文献单书/批量结果，支持 PDF附件，中文作者单字段保存。
- **China National Library - Modern Newspaper Database.js**：抓取近代报纸数据库篇目与报纸信息。
- **Wikimedia Commons.js**：解析 Commons 图书文件页与搜索，提取 `{{Book}}`/`{{Information}}` 模板元数据并附加原文件；支持对单部著作的元数据抓取，支持保存PDF附件。