### PR TITLE
fix(CNKI): support current PDF and CAJ download selectors

### DIFF
--- a/CNKI.js
+++ b/CNKI.js
@@ -9,7 +9,7 @@
 	"inRepository": true,
 	"translatorType": 4,
 	"browserSupport": "gcsibv",
-	"lastUpdated": "2026-05-06 05:49:57"
+	"lastUpdated": "2026-07-23 07:36:44"
 }
 
 /*
@@ -756,6 +756,16 @@ function cleanAuthor(string, creatorType = 'author') {
 		: ZU.cleanAuthor(ZU.capitalizeName(string), creatorType);
 }
 
+function getDownloadLink(doc, selectors) {
+	for (const selector of selectors) {
+		const node = doc.querySelector(selector);
+		if (!node) continue;
+		const resolvedURL = node.href || '';
+		if (/^https?:\/\//i.test(resolvedURL)) return resolvedURL;
+	}
+	return '';
+}
+
 function addAttachments(item, doc) {
 	// If you want CAJ instead of PDF, set keepPDF = false
 	// 如果你想将PDF文件替换为CAJ文件，将下面一行 keepPDF 设为 false
@@ -777,22 +787,32 @@ function addAttachments(item, doc) {
 			});
 		}
 	}
-	const pdfLink = attr(doc, '.btn-dlpdf > a', 'href');
+	const pdfLink = getDownloadLink(doc, [
+		'a#pdfDown',
+		'a[name="pdfDown"]',
+		'.btn-dlpdf > a'
+	]);
 	Z.debug(`get PDF Link:\n${pdfLink}`);
-	const cajLink = attr(doc, '.btn-dlcaj > a', 'href');
+	const cajLink = getDownloadLink(doc, [
+		'a#cajDown',
+		'a[name="cajDown"]',
+		'.btn-dlcaj > a'
+	]);
 	Z.debug(`get CAJ link:\n${cajLink}`);
 	if (keepPDF && pdfLink) {
 		item.attachments.push({
 			title: 'Full Text PDF',
 			mimeType: 'application/pdf',
-			url: pdfLink
+			url: pdfLink,
+			proxy: false
 		});
 	}
 	else if (cajLink) {
 		item.attachments.push({
 			title: 'Full Text CAJ',
 			mimeType: 'application/caj',
-			url: cajLink
+			url: cajLink,
+			proxy: false
 		});
 	}
 }


### PR DESCRIPTION
Fixes #945

## What changed

- support the current CNKI PDF controls identified by `a#pdfDown` and `a[name="pdfDown"]`
- support the equivalent current CAJ controls
- retain `.btn-dlpdf > a` and `.btn-dlcaj > a` for older page layouts
- resolve links through the DOM, accept only HTTP(S) URLs, and mark direct attachments with `proxy: false`
- preserve the existing PDF-preferred and CAJ-fallback behavior

## Why

CNKI's current `/kcms2/article/abstract` page can expose the download anchor without the `.btn-dlpdf` wrapper used by the existing translator. In that layout, the old selector returns no URL, so the translator saves metadata but does not create a PDF attachment object even though manual download works.

## Impact

Current CNKI detail pages can submit PDF or CAJ attachment URLs again, while older layouts and the existing `CNKIPDF` preference remain supported. The translator ID, target, priority, and repository metadata are unchanged.

## Validation

- `./node_modules/.bin/eslint CNKI.js` passed after supplying a temporary untracked empty `deleted.txt` required by the repository's current linter plugin
- focused behavior tests passed for the new ID selector, name fallback, legacy selector, relative URL resolution, non-HTTP rejection, PDF preference, and CAJ fallback
- `git diff --check` passed
- full `npm test` reaches the repository-wide lint suite but fails on 370 pre-existing problems in unrelated files; `CNKI.js` has no reported lint issue

## Limitation

The live CNKI check was redirected to the site's security verification page. I did not bypass the CAPTCHA, so this remains a Draft until a no-CAPTCHA Connector download can be confirmed.
